### PR TITLE
[Phase 1] LangGraph 그래프 기반 구축 (state, builder, 테스트)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 GOOGLE_API_KEY=
 GOOGLE_MODEL=gemini-2.5-flash
 
+# Checkpointer (memory | sqlite) — 기본값 memory, 운영 시 sqlite로 변경
+GRAPH_CHECKPOINTER=memory
+SQLITE_DB_PATH=./checkpoints.db
+
 # Ollama (로컬 Llama 실행 환경 구축 후 교체)
 # OLLAMA_BASE_URL=http://localhost:11434
 # OLLAMA_MODEL=llama3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,10 @@ prompts/ *.txt   tests/       main.py        server.py
 
 ## Data Models (`graph/state.py`)
 
-**Enums (StrEnum):** `IncomeLevel` (`기초수급`/`차상위`/`저소득`/`일반`) · `Gender` (`남성`/`여성`) · `EmploymentStatus` (`취업`/`실업`/`비경제활동`) · `MaritalStatus` (`미혼`/`기혼`/`이혼`/`사별`) · `DisabilitySeverity` (`경증`/`중증`)
+**Enums (StrEnum):** `IncomeLevel` (`기초수급`/`차상위`/`저소득`/`일반`) · `EmploymentStatus` (`취업`/`실업`/`비경제활동`) · `MaritalStatus` (`미혼`/`기혼`/`이혼`/`사별`) · `DisabilitySeverity` (`경증`/`중증`)
 
 **`UserProfile`** (Pydantic BaseModel)
-- Step-1: `age`, `gender`, `region`, `household_size`, `marital_status`, `has_children`, `disability`, `employment_status`, `income_level`
+- Step-1: `age`, `region`, `household_size`, `marital_status`, `has_children`, `disability`, `employment_status`, `income_level`
 - `disability_severity` — conditional, only when `disability=True`; no model-level validator (enforced by interview logic)
 - `is_elderly` — `@computed_field` from `age >= 65`; never set directly
 - Step-2: `disability_type`, `disability_grade`, `children_ages`, `housing_type`, `household_type`, `is_veteran`, `is_single_parent`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,13 +158,12 @@ graph.invoke(Command(resume=user_input), config)
 Two HTTP calls to the `rag/` service. **Do not change the JSON shape without coordinating with `rag/`.**
 
 ```
-POST /search
+POST /welfare/search
 Body:  { "profile": { "age": 65, "income_level": "기초생활수급자", ... }, "top_k": 5 }
 Response: [{ "id", "name", "department", "summary", "eligibility_reason", "score" }, ...]
 # Empty list [] = no results; pipeline ends, no LLM fallback
 
-POST /services/detail
-Body:  { "service_id": "welfare_001" }
+GET /welfare/{serv_id}
 Response: { "id", "name", "required_documents", "application_fields", "application_url", ... }
 # application_fields is required by draft_writer
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,240 +10,94 @@ Uses **`uv`**. All Python commands must be prefixed with `uv run`.
 uv sync --all-groups          # install all deps (first time)
 uv add <pkg>                  # add runtime dep
 uv add --group dev <pkg>      # add dev dep
-uv add --group test <pkg>     # add test dep
-
 uv run python main.py         # run agent
-uv run ruff check .           # lint
 uv run ruff check --fix .     # lint + auto-fix
 uv run ruff format .          # format
 uv run pytest tests/ -v       # all tests
-uv run pytest tests/test_file.py::test_fn -v  # single test
 uv run pre-commit install     # register hooks (once per clone)
 ```
 
 ## Architecture
 
-An 8-node **LangGraph** pipeline. Nodes execute in order; two nodes have re-entry loops and one has a Human-in-the-Loop pause.
+8-node LangGraph pipeline. See `docs/development_plan.md` for full design.
 
 ```
-START
-  │
-  ▼
-initial_interview ◄──────────────────┐  (re-entry loop: missing fields)
-  │ min fields collected             │
-  ▼                                  │
-rag_search ──(no results)──► END     │
-  │ candidates found                 │
-  ▼                                  │
-service_select  ← user picks (HitL)  │
-  │                                  │
-  ▼                                  │
-rag_detail                           │
-  │                                  │
-  ▼                                  │
-detail_interview ◄───────────────────┘  (re-entry loop: missing fields)
-  │ all fields collected
-  ▼
-document_guidance
-  ▼
-draft_writer
-  ▼
-report_writer
-  ▼
-END
+START → initial_interview ⟲ → rag_search → service_select(HitL) → rag_detail → detail_interview ⟲ → document_guidance → draft_writer → report_writer → END
 ```
 
-### Target directory layout
-
 ```
-agents/
-  initial_interview.py   # Step 1 interview — collects minimum profile fields
-  rag_search.py          # RAG candidate search — JSON profile → N welfare services
-  service_select.py      # HitL pause — user selects a service
-  rag_detail.py          # RAG detail fetch — fills selected_service fields
-  detail_interview.py    # Step 2 interview — service-specific additional fields
-  document_guidance.py   # Lists required documents
-  draft_writer.py        # Per-field application guide (no HWP generation)
-  report_writer.py       # Reformats guide into user-friendly report
-graph/
-  state.py               # AgentState, UserProfile, WelfareCandidate
-  builder.py             # StateGraph wiring, conditional edges, checkpointer
-tools/
-  llm.py                 # get_llm() factory (Gemini now, Ollama later)
-  rag_client.py          # httpx async client for RAG service (Phase 3)
-  prompt_loader.py       # loads prompts/{name}.txt files
-prompts/
-  initial_interview.txt
-  detail_interview.txt
-  document_guidance.txt
-  draft_writer.txt
-  report_writer.txt
-tests/
-  conftest.py            # mock_llm and mock_rag_client fixtures
-  test_smoke.py
-  test_state.py / test_graph.py / test_e2e.py / ...
-main.py                  # CLI entry point (Phase 5: interactive loop)
-server.py                # FastAPI mode for Next.js (Phase 5)
+graph/ state.py builder.py   agents/ *.py   tools/ llm.py rag_client.py prompt_loader.py
+prompts/ *.txt   tests/       main.py        server.py
 ```
 
 ## Data Models (`graph/state.py`)
 
-Three Pydantic models define the shared state:
+**Enums (StrEnum):** `IncomeLevel` (`기초수급`/`차상위`/`저소득`/`일반`) · `Gender` (`남성`/`여성`) · `EmploymentStatus` (`취업`/`실업`/`비경제활동`) · `MaritalStatus` (`미혼`/`기혼`/`이혼`/`사별`) · `DisabilitySeverity` (`경증`/`중증`)
 
-**`UserProfile`** — grows incrementally across both interviews.
-- Step-1 minimum fields: `age`, `household_size`, `marital_status`, `has_children`, `disability`, `disability_severity`, `employment_status`, `region`, `income_level`
-  - `income_level` uses `IncomeLevel` Enum (`기초생활수급자` / `차상위계층` / `저소득` / `일반`) — LLM determines this from conversation, not direct user input
-  - `employment_status` uses `EmploymentStatus` Enum (`취업` / `실업` / `비경제활동`)
-  - `marital_status` uses `MaritalStatus` Enum (`미혼` / `기혼` / `이혼` / `사별`)
-  - `disability_severity` uses `DisabilitySeverity` Enum (`경증` / `중증`) — only collected when `disability=True`
-  - `is_elderly` is a `@computed_field` derived from `age >= 65` — never set it directly
-- Step-2 service-specific fields: `disability_type`, `disability_grade`, `children_ages`, `housing_type`, `household_type`, `is_veteran`, `is_single_parent`, etc.
-- `extra_fields: dict[str, str | int | bool]` — catch-all for fields not in the model; keys are later promoted to regular fields if they appear often
-- See `docs/state_design.md` for full field list and income_level collection flow
+**`UserProfile`** (Pydantic BaseModel)
+- Step-1: `age`, `gender`, `region`, `household_size`, `marital_status`, `has_children`, `disability`, `employment_status`, `income_level`
+- `disability_severity` — conditional, only when `disability=True`; no model-level validator (enforced by interview logic)
+- `is_elderly` — `@computed_field` from `age >= 65`; never set directly
+- Step-2: `disability_type`, `disability_grade`, `children_ages`, `housing_type`, `household_type`, `is_veteran`, `is_single_parent`
+- `extra_fields: dict[str, str | int | bool] = {}` — safe mutable default in Pydantic v2
 
-**`WelfareCandidate`** — one entry per RAG result.
-- Phase 1 (after `rag_search`): `service_id`, `service_name`, `department`, `eligibility_reason`, `summary`, `score`, `priority`
-  - `department` and `eligibility_reason` are required fields (no default) — must be present in RAG `/search` response
-- Phase 2 (after `rag_detail`): `required_documents`, `application_fields`, `application_url`, `detail_fetched=True`
-- `priority` is computed inside `rag_search_node` from `score` descending order — not provided by RAG
+**`WelfareCandidate`** (Pydantic BaseModel) — field names match RAG API exactly
+- Required: `serv_id`, `serv_nm`, `serv_dgst`
+- Defaults: `department=""`, `eligibility_reason=""` (LLM-generated), `score=0.0`, `priority=0`
+- Phase 2: `required_documents=[]`, `application_fields=[]`, `application_url=None`, `detail_fetched=False`
 
-**`AgentState`** (`TypedDict`):
+**`AgentState`** (TypedDict) — all fields must be provided explicitly in `graph.invoke()`
 ```python
-messages: Annotated[list[BaseMessage], add_messages]  # use add_messages Reducer
+messages: Annotated[list[BaseMessage], add_messages]
 user_profile: UserProfile
 initial_missing_fields: list[str]
 welfare_candidates: list[WelfareCandidate]
 selected_service: WelfareCandidate | None
-detail_missing_fields: list[str]    # "extra:" prefix for extra_fields keys
+detail_missing_fields: list[str]   # "extra:" prefix for extra_fields keys
 document_guidance: str
 application_guide: str
 final_report: str
 ```
 
-## Key Behavioral Constraints
-
-**No LLM fallback on empty RAG results.** If `rag_search` returns `[]`, the pipeline terminates with a user-facing message. LLMs must not fabricate welfare services.
-
-**`rag_detail` uses LLM (structured output) to compute `detail_missing_fields`.** After fetching RAG detail, the node passes the service `eligibility` object to the LLM and asks it to infer which `UserProfile` fields are still missing. Returns `list[str]`.
-
-**`detail_interview` is a pass-through when `detail_missing_fields` is empty.** If `rag_detail` determines no additional fields are needed, `detail_interview` returns immediately without any LLM call. `route_after_detail_interview` then routes directly to `document_guidance`.
-
-**`detail_missing_fields` field naming convention:**
-- Regular `UserProfile` field → plain name, e.g. `"household_size"`
-- Field not in model → `"extra:"` prefix, e.g. `"extra:deposit_amount"` → stored in `user_profile.extra_fields`
-
-**`draft_writer` does not generate HWP files.** It produces per-field text guidance showing how to fill in each field. Unknown items are marked `[직접 확인 필요: 이유]`.
-
-**`report_writer` does not add new information.** It only reformats `application_guide` + `document_guidance` into readable Markdown.
-
-## Checkpointer (`graph/builder.py`)
-
-`service_select` uses LangGraph `interrupt()` for Human-in-the-Loop. A checkpointer is required for this to work.
-
-| `GRAPH_CHECKPOINTER` value | Storage | When to use |
-|---|---|---|
-| `memory` | RAM (lost on restart) | Development / tests |
-| `sqlite` | `./checkpoints.db` file | Phase 5 production |
-| `postgres` | External DB | High-traffic future |
-
-Resume pattern:
-```python
-# CLI / test: resume after interrupt
-graph.invoke(Command(resume=user_input), config)
-# FastAPI: POST /resume with selected value
-```
-
 ## RAG API Contract
-
-Two HTTP calls to the `rag/` service. **Do not change the JSON shape without coordinating with `rag/`.**
 
 ```
 POST /welfare/search
-Body:  { "profile": { "age": 65, "income_level": "기초생활수급자", ... }, "top_k": 5 }
-Response: [{ "id", "name", "department", "summary", "eligibility_reason", "score" }, ...]
-# Empty list [] = no results; pipeline ends, no LLM fallback
+Body:  { "age": 65, "income_level": "기초수급", "gender": "여성", ... }  # flat JSON, no wrapper
+Response: [{ "serv_id", "serv_nm", "serv_dgst", "department", "score" }, ...]
 
 GET /welfare/{serv_id}
-Response: { "id", "name", "required_documents", "application_fields", "application_url", ... }
-# application_fields is required by draft_writer
+Response: { "serv_id", "serv_nm", "required_documents", "application_fields", "application_url", ... }
 ```
+- Empty `[]` from search → pipeline ends, no LLM fallback
+- `eligibility_reason` is NOT in RAG response — LLM generates it from `serv_dgst`
+- `required_documents` / `application_fields` currently return `[]` (RAG not yet implemented)
 
-RAG converts the JSON profile to natural language internally; the AI side only sends structured JSON.
+## Checkpointer
 
-## Prompt Management
+`GRAPH_CHECKPOINTER=memory` (dev) / `sqlite` (prod). `service_select` uses `interrupt()` for HitL — checkpointer required.
 
-System prompts live in `prompts/*.txt` and are loaded at import time via `tools/prompt_loader.py`. Variable substitution uses Python f-strings or `str.format()` — no template engine.
+## Key Constraints
 
-```python
-from tools.prompt_loader import load_prompt
-SYSTEM_PROMPT = load_prompt("initial_interview")  # reads prompts/initial_interview.txt
-```
-
-## LLM Factory (`tools/llm.py`)
-
-`get_llm()` is the single swap point. Currently Gemini; Ollama block is commented out.
-All agent nodes must call `get_llm()` — never import an LLM directly.
+- All agent nodes are `async def`; return partial `AgentState` dict
+- RAG HTTP calls only through `tools/rag_client.py` — never call `httpx` directly
+- `get_llm()` is the only LLM import point — never import LLM directly
+- `draft_writer` produces text guidance only — no HWP generation
+- `report_writer` reformats only — no new information added
 
 ## Environment Variables
 
 ```dotenv
-# Phase 1–3 (Gemini)
 GOOGLE_API_KEY=
 GOOGLE_MODEL=gemini-2.5-flash
-
-# Checkpointer
-GRAPH_CHECKPOINTER=memory          # memory | sqlite | postgres
-SQLITE_DB_PATH=./checkpoints.db    # if sqlite
-
-# Phase 3 — RAG integration
+GRAPH_CHECKPOINTER=memory
+SQLITE_DB_PATH=./checkpoints.db
 RAG_SERVICE_URL=http://localhost:8000
 RAG_SEARCH_TOP_K=5
-RAG_TIMEOUT_SECONDS=10
-RAG_MAX_RETRIES=1
-
-# Phase 4 — Ollama migration
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=llama3
-
-# Phase 5 — FastAPI server
-SERVER_HOST=0.0.0.0
-SERVER_PORT=8001
 ```
 
 ## Testing
 
-`asyncio_mode = "auto"` — no decorator needed on async test functions.
-
-**Mocking strategy** (`tests/conftest.py`):
-```python
-@pytest.fixture
-def mock_llm():
-    llm = MagicMock()
-    llm.invoke.return_value.content = "모킹된 응답"
-    return llm
-
-@pytest.fixture
-def mock_rag_client():
-    client = AsyncMock()
-    # WARNING: include ALL required WelfareCandidate fields (department, eligibility_reason have no default)
-    client.search.return_value = [{
-        "id": "welfare_001", "name": "기초연금", "department": "보건복지부",
-        "eligibility_reason": "나이 65세 이상, 기초생활수급자", "summary": "...", "score": 0.95,
-    }]
-    client.get_detail.return_value = {
-        "id": "welfare_001", "required_documents": [...],
-        "application_fields": [...], "application_url": "...",
-    }
-    return client
-```
-
-RAG nodes (`rag_search`, `rag_detail`) must inject the client so it can be mocked in tests. Direct HTTP calls inside agents are forbidden — use `tools/rag_client.py`.
-
-## Code Conventions
-
-- Python ≥ 3.11, line length 88, Google docstring style
-- `| None` over `Optional[...]`
-- All agent nodes are `async def` — RAG client uses `httpx.AsyncClient`; do not mix sync and async nodes
-- All agent nodes take `AgentState` as input and return a partial `AgentState` dict
-- RAG HTTP calls go through `tools/rag_client.py` — never call `httpx` directly in agents
-- `AgentState` initial values must be explicitly provided in `graph.invoke()` — TypedDict has no defaults
+`asyncio_mode = "auto"`. Mock fixtures in `tests/conftest.py`:
+- `mock_llm`: `llm.invoke.return_value.content = "모킹된 응답"`
+- `mock_rag_client`: `serv_id`/`serv_nm`/`serv_dgst` are required — include all three in mock data

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -224,9 +224,17 @@ class WelfareCandidate(BaseModel):
     eligibility_reason: str = ""           # rag_search_node에서 LLM으로 생성
     score: float = 0.0
     priority: int = 0                      # score 내림차순 정렬 후 rag_search_node가 부여
-    # ── 2차 RAG 상세 조회 후 채워짐 ──
-    required_documents: list[str] = []    # GET /welfare/{serv_id} 응답 (현재 빈 배열)
-    application_fields: list[str] = []    # GET /welfare/{serv_id} 응답 (현재 빈 배열)
+    # ── 2차 RAG 상세 조회 후 채워짐 (Phase 2 rag_detail_node 구현 시 추가) ──
+    # GET /welfare/{serv_id} 응답 필드:
+    #   tgtr_dtl_cn: str   — 수급 대상 상세 (detail_missing_fields 결정에 사용)
+    #   slct_crit_cn: str  — 선정 기준
+    #   alw_serv_cn: str   — 서비스 내용
+    #   sprt_cyc_nm: str   — 지원 주기
+    #   srv_pvsn_nm: str   — 제공 방법
+    #   trgter_indvdl: list[str]
+    #   intrs_thema: list[str]
+    required_documents: list[str] = []    # 현재 빈 배열로 수신 (RAG 미구현)
+    application_fields: list[str] = []    # 현재 빈 배열로 수신 (RAG 미구현)
     application_url: str | None = None
     detail_fetched: bool = False
 ```

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -182,14 +182,9 @@ class DisabilitySeverity(StrEnum):
     MILD = "경증"
     SEVERE = "중증"
 
-class Gender(StrEnum):
-    MALE = "남성"
-    FEMALE = "여성"
-
 class UserProfile(BaseModel):
     # ── 1단계: RAG 검색 최소 필드 ──
     age: int | None = None
-    gender: Gender | None = None           # 여성 전용 서비스 필터링, 임신 여부 조건부 수집
     region: str | None = None
     household_size: int | None = None      # 소득 구간 판단 선행 조건
     marital_status: MaritalStatus | None = None

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -178,13 +178,18 @@ class MaritalStatus(str, Enum):
     DIVORCED = "이혼"
     WIDOWED = "사별"
 
-class DisabilitySeverity(str, Enum):
+class DisabilitySeverity(StrEnum):
     MILD = "경증"
     SEVERE = "중증"
+
+class Gender(StrEnum):
+    MALE = "남성"
+    FEMALE = "여성"
 
 class UserProfile(BaseModel):
     # ── 1단계: RAG 검색 최소 필드 ──
     age: int | None = None
+    gender: Gender | None = None           # 여성 전용 서비스 필터링, 임신 여부 조건부 수집
     region: str | None = None
     household_size: int | None = None      # 소득 구간 판단 선행 조건
     marital_status: MaritalStatus | None = None
@@ -193,7 +198,6 @@ class UserProfile(BaseModel):
     disability_severity: DisabilitySeverity | None = None  # disability=True일 때만
     employment_status: EmploymentStatus | None = None
     income_level: IncomeLevel | None = None  # LLM이 대화로 판단, 직접 입력 X
-    pregnant: bool | None = None           # RAG search 요청 필드
 
     @computed_field
     @property

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -575,6 +575,7 @@ Response: {
 
 | # | 작업 |
 |---|------|
+| 5-0 | **`graph/builder.py` SQLite checkpointer 수정** (B 담당): `langgraph-checkpoint-sqlite` 패키지 설치 + `AsyncSqliteSaver.from_conn_string()`을 `async with` 컨텍스트로 올바르게 사용하도록 `_build_checkpointer()` 리팩터링 필요. 현재 sqlite 모드 실행 시 오류 발생 |
 | 5-1 | 에러 처리 보강: LLM 응답 파싱 실패 최대 재시도 횟수 조정, 회복 불가 시 사용자 친화적 메시지 출력 |
 | 5-2 | 대화 히스토리 관리: 컨텍스트 길이 초과 방지 (요약 또는 슬라이딩 윈도우) |
 | 5-3 | `main.py` CLI 인터페이스 구현 (대화형 루프, 서비스 선택 UX 포함, `interrupt()` 재개 패턴 포함) |

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -271,6 +271,10 @@ class AgentState(TypedDict):
 
 > **구현 시 주의:** `AgentState`는 `TypedDict`이므로 기본값을 선언부에 지정할 수 없습니다. 그래프 진입 시 `graph.invoke()`에 전달하는 초기 상태 딕셔너리에서 모든 필드의 기본값(예: `initial_missing_fields=[]`, `welfare_candidates=[]`, `document_guidance=""` 등)을 명시적으로 채워줘야 합니다. 누락된 필드에 접근하면 `KeyError`가 발생합니다.
 
+> **`disability_severity` 유효성 검사 없음:** `UserProfile` 모델 레벨에서 `disability=False`일 때 `disability_severity`를 자동으로 `None`으로 설정하는 validator가 없습니다. `disability=True`일 때만 수집하는 것은 인터뷰 로직이 담당합니다. 모델에 직접 `disability=False, disability_severity="중증"`을 주입하면 오류 없이 저장됩니다. 테스트 시 주의하세요.
+
+> **`extra_fields` 뮤터블 기본값 안전함:** `extra_fields: dict[str, str | int | bool] = {}`처럼 Pydantic `BaseModel`에서 뮤터블 기본값을 선언해도 안전합니다. Pydantic v2는 인스턴스 생성 시마다 새 딕셔너리를 복사하므로 인스턴스 간 상태가 공유되지 않습니다. (`dataclass`나 순수 Python 클래스와 다름)
+
 ---
 
 ## 4. 개발 단계별 계획

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -162,8 +162,9 @@ from enum import Enum
 from pydantic import BaseModel, computed_field
 
 class IncomeLevel(str, Enum):
-    BASIC = "기초생활수급자"
-    NEAR_POOR = "차상위계층"
+    BASIC = "기초수급"        # RAG 팀 필드값 기준으로 통일
+    NEAR_POOR = "차상위"
+    LOW_INCOME = "저소득"
     GENERAL = "일반"
 
 class EmploymentStatus(str, Enum):
@@ -171,32 +172,43 @@ class EmploymentStatus(str, Enum):
     UNEMPLOYED = "실업"
     INACTIVE = "비경제활동"
 
+class MaritalStatus(str, Enum):
+    SINGLE = "미혼"
+    MARRIED = "기혼"
+    DIVORCED = "이혼"
+    WIDOWED = "사별"
+
+class DisabilitySeverity(str, Enum):
+    MILD = "경증"
+    SEVERE = "중증"
+
 class UserProfile(BaseModel):
-    # ── 1단계 인터뷰에서 수집하는 최소 필드 ──
+    # ── 1단계: RAG 검색 최소 필드 ──
     age: int | None = None
-    income_level: IncomeLevel | None = None
-    disability: bool | None = None         # 장애 여부
-    # is_elderly 제거: age >= 65로 파생 가능 → @computed_field로 처리하여 불일치 방지
+    region: str | None = None
+    household_size: int | None = None      # 소득 구간 판단 선행 조건
+    marital_status: MaritalStatus | None = None
+    has_children: bool | None = None
+    disability: bool | None = None
+    disability_severity: DisabilitySeverity | None = None  # disability=True일 때만
+    employment_status: EmploymentStatus | None = None
+    income_level: IncomeLevel | None = None  # LLM이 대화로 판단, 직접 입력 X
+    pregnant: bool | None = None           # RAG search 요청 필드
+
     @computed_field
     @property
     def is_elderly(self) -> bool | None:
         return self.age >= 65 if self.age is not None else None
-    employment_status: EmploymentStatus | None = None
-    region: str | None = None              # 거주 지역 (시/군/구)
 
-    # ── 2단계 인터뷰에서 예상 가능한 서비스 특화 필드 ──
-    has_children: bool | None = None       # 아동/청소년 자녀 여부
-    household_size: int | None = None      # 가구원 수
-    disability_grade: str | None = None    # 장애 등급 (장애인 서비스 선택 시)
-    is_single_parent: bool | None = None   # 한부모 여부 (한부모 서비스 선택 시)
-    children_ages: list[int] | None = None # 자녀 나이 목록 (아동수당 등 선택 시)
-    housing_type: str | None = None        # 주거 형태 (주거급여 선택 시)
-    is_veteran: bool | None = None         # 국가유공자 여부
+    # ── 2단계: 서비스 특화 필드 ──
+    disability_type: str | None = None
+    disability_grade: str | None = None
+    children_ages: list[int] | None = None
+    housing_type: str | None = None
+    household_type: str | None = None
+    is_veteran: bool | None = None
+    is_single_parent: bool | None = None
 
-    # ── catch-all: 위 정규 필드에 없는 서비스 특화 필드 ──
-    # RAG 상세 정보에서 요구하지만 모델에 정의되지 않은 항목을 동적으로 저장
-    # 예: {"deposit_amount": 50000000, "vehicle_owned": False, "veteran_number": "12345"}
-    # 자주 등장하는 키는 이후 정규 필드로 승격
     extra_fields: dict[str, str | int | bool] = {}
 ```
 
@@ -204,19 +216,19 @@ class UserProfile(BaseModel):
 
 ```python
 class WelfareCandidate(BaseModel):
-    service_id: str                        # RAG 문서 ID (RAG /search 응답의 "id")
-    service_name: str                      # 복지 서비스명 (RAG /search 응답의 "name")
-    department: str                        # 담당 기관 (RAG /search 응답의 "department")
-    eligibility_reason: str               # 해당 이유: RAG /search 응답의 "eligibility_reason" 필드
-                                           # (RAG가 검색 결과에 포함해야 함 — rag/ 파트 협의 필요)
-    summary: str                           # 서비스 요약 (RAG /search 응답의 "summary")
-    score: float = 0.0                     # RAG 유사도 점수 (RAG /search 응답의 "score")
-    priority: int = 0                      # 우선순위: score 내림차순 정렬 후 순위로 설정 (rag_search_node 내부 계산)
-    # 상세 정보는 서비스 선택 후 rag_detail에서 채워짐
-    required_documents: list[str] = []    # 필요 서류 목록 (2차 RAG 후 채워짐)
-    application_fields: list[str] = []    # 신청서 항목 목록 (2차 RAG 후 채워짐 — draft_writer가 사용)
-    application_url: str | None = None    # 신청 URL (2차 RAG 후 채워짐)
-    detail_fetched: bool = False          # 상세 정보 조회 완료 여부
+    # ── 1차 RAG 검색 후 채워짐 (필드명 RAG 응답 기준) ──
+    serv_id: str                           # RAG /welfare/search 응답의 "serv_id"
+    serv_nm: str                           # RAG /welfare/search 응답의 "serv_nm"
+    serv_dgst: str                         # RAG /welfare/search 응답의 "serv_dgst"
+    jur_mnof_nm: str | None = None         # 담당 기관명 — RAG search 응답 추가 요청 예정
+    eligibility_reason: str = ""           # rag_search_node에서 LLM으로 생성
+    score: float = 0.0
+    priority: int = 0                      # score 내림차순 정렬 후 rag_search_node가 부여
+    # ── 2차 RAG 상세 조회 후 채워짐 ──
+    required_documents: list[str] = []    # GET /welfare/{serv_id} 응답 (현재 빈 배열)
+    application_fields: list[str] = []    # GET /welfare/{serv_id} 응답 (현재 빈 배열)
+    application_url: str | None = None
+    detail_fetched: bool = False
 ```
 
 ### AgentState
@@ -468,9 +480,12 @@ def route_after_detail_interview(state: AgentState) -> str:
 | 3-5 | RAG 통합 테스트 | `tests/test_rag_integration.py` |
 
 **RAG API 계약** (Phase 2 모킹의 기준 — 아래 스키마 기준으로 스텁 및 모킹 구현):
+
+> **확정 스펙 (2026-04-20 rag/ 팀 PR #7 기준):** 엔드포인트 경로 및 메서드가 아래와 같이 확정되었습니다.
+
 ```
 # 1차: 후보 목록 검색 — AI는 JSON을 전송, 자연어 변환은 RAG 내부에서 처리
-POST /search
+POST /welfare/search
 Body: {
   "profile": {
     "age": 65,
@@ -494,9 +509,8 @@ Response: [
 ]
 # 결과 없으면: []  (LLM 폴백 없음 — 빈 목록 그대로 반환)
 
-# 2차: 상세 정보 조회 — 서비스 ID로 조회
-POST /services/detail
-Body: { "service_id": "welfare_001" }
+# 2차: 상세 정보 조회 — 서비스 ID를 경로 파라미터로 조회 (POST → GET 변경)
+GET /welfare/{serv_id}
 Response: {
   "id": "welfare_001",
   "name": "기초연금",
@@ -578,7 +592,7 @@ Response: {
 **출력:** 업데이트된 `welfare_candidates`
 
 **핵심 동작:**
-1. `user_profile` 최소 필드를 JSON으로 직렬화하여 RAG 서비스 `/search`에 전송
+1. `user_profile` 최소 필드를 JSON으로 직렬화하여 RAG 서비스 `POST /welfare/search`에 전송
 2. 자연어 변환은 RAG 서비스 내부에서 처리 — AI 파트는 JSON 전송만 담당
 3. 응답을 `WelfareCandidate` 목록으로 변환 (상세 정보 미포함 상태)
 4. **결과가 빈 목록인 경우 LLM 폴백 없이 사용자에게 "해당하는 서비스를 찾지 못했습니다" 안내 후 END로 라우팅**
@@ -605,7 +619,7 @@ Response: {
 **출력:** 업데이트된 `selected_service`(상세 필드 채워짐), `detail_missing_fields`
 
 **핵심 동작:**
-1. `selected_service.service_id`로 RAG `/services/detail` 조회
+1. `selected_service.service_id`로 RAG `GET /welfare/{serv_id}` 조회
 2. 응답으로 `selected_service`의 `required_documents`, `application_url` 등 상세 필드 채우기
 3. RAG 응답의 자격 요건(`eligibility`)을 **LLM에 전달(structured output)**하여 현재 `user_profile`에서 부족한 필드 목록을 추론 → `detail_missing_fields`에 설정
    - `UserProfile` 정규 필드에 있으면 → 필드명 그대로 추가 (예: `"household_size"`)
@@ -720,19 +734,22 @@ def mock_llm():
 def mock_rag_client():
     client = AsyncMock()
     # 1차 검색 응답 모킹 (아래는 예시 — 실제 구현 시 RAG API 계약 스키마에 맞춰 모든 필수 필드 포함)
-    client.search.return_value = [
-        {"id": "welfare_001", "name": "기초연금", "summary": "만 65세 이상 저소득 노인 연금", "score": 0.95},
-    ]
-    # 2차 상세 조회 응답 모킹 (아래는 예시 — 실제 구현 시 RAG API 계약 스키마에 맞춰 모든 필수 필드 포함)
+    client.search.return_value = {
+        "results": [
+            {"serv_id": "WLF00000035", "serv_nm": "기초연금", "serv_dgst": "만 65세 이상 저소득 노인 연금", "score": 0.95},
+        ]
+    }
+    # 2차 상세 조회 응답 모킹
     client.get_detail.return_value = {
-        "id": "welfare_001",
-        "required_documents": ["신분증", "통장사본"],
+        "serv_id": "WLF00000035",
+        "required_documents": [],   # 현재 빈 배열로 합의
+        "application_fields": [],   # 현재 빈 배열로 합의
         "application_url": "https://www.bokjiro.go.kr",
     }
     return client
 ```
 
-> **모킹 스키마 준수:** 위 예시는 구조를 보여주기 위한 것입니다. 실제 구현 시에는 `WelfareCandidate` 모델의 필수 필드(`department`, `eligibility_reason` 등 기본값 없는 필드 포함)를 모두 채운 응답을 모킹해야 합니다. 스키마 기준은 본 문서의 RAG API 계약 섹션을 따릅니다.
+> **모킹 스키마 준수:** 필드명은 RAG API 응답 기준(`serv_id`, `serv_nm`, `serv_dgst`)을 따릅니다. `required_documents`, `application_fields`는 현재 RAG API 미구현으로 빈 배열로 수신합니다.
 
 ### 테스트 시나리오 (E2E)
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -220,7 +220,7 @@ class WelfareCandidate(BaseModel):
     serv_id: str                           # RAG /welfare/search 응답의 "serv_id"
     serv_nm: str                           # RAG /welfare/search 응답의 "serv_nm"
     serv_dgst: str                         # RAG /welfare/search 응답의 "serv_dgst"
-    jur_mnof_nm: str | None = None         # 담당 기관명 — RAG search 응답 추가 요청 예정
+    department: str = ""                   # 담당 기관명 — RAG /welfare/search 응답의 "department"
     eligibility_reason: str = ""           # rag_search_node에서 LLM으로 생성
     score: float = 0.0
     priority: int = 0                      # score 내림차순 정렬 후 rag_search_node가 부여

--- a/graph/builder.py
+++ b/graph/builder.py
@@ -1,0 +1,131 @@
+import os
+
+from dotenv import load_dotenv
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.constants import END, START
+from langgraph.graph import StateGraph
+
+from graph.state import AgentState
+
+load_dotenv()
+
+
+# ── 조건부 엣지 함수 ──
+
+
+def route_after_initial_interview(state: AgentState) -> str:
+    """1단계 인터뷰 후 라우팅: 누락 필드 있으면 재진입, 없으면 rag_search."""
+    if state["initial_missing_fields"]:
+        return "initial_interview"
+    return "rag_search"
+
+
+def route_after_rag_search(state: AgentState) -> str:
+    """RAG 검색 후 라우팅: 후보 없으면 END, 있으면 service_select."""
+    if not state["welfare_candidates"]:
+        return END
+    return "service_select"
+
+
+def route_after_detail_interview(state: AgentState) -> str:
+    """2단계 인터뷰 후 라우팅: 누락 필드 있으면 재진입, 없으면 document_guidance."""
+    if state["detail_missing_fields"]:
+        return "detail_interview"
+    return "document_guidance"
+
+
+# ── stub 노드 (Phase 2에서 실제 구현으로 교체) ──
+
+
+async def initial_interview_node(state: AgentState) -> dict:
+    """1단계 인터뷰 stub."""
+    return {}
+
+
+async def rag_search_node(state: AgentState) -> dict:
+    """RAG 후보 검색 stub."""
+    return {}
+
+
+async def service_select_node(state: AgentState) -> dict:
+    """서비스 선택 HitL stub."""
+    return {}
+
+
+async def rag_detail_node(state: AgentState) -> dict:
+    """RAG 상세 조회 stub."""
+    return {}
+
+
+async def detail_interview_node(state: AgentState) -> dict:
+    """2단계 인터뷰 stub."""
+    return {}
+
+
+async def document_guidance_node(state: AgentState) -> dict:
+    """서류 안내 stub."""
+    return {}
+
+
+async def draft_writer_node(state: AgentState) -> dict:
+    """신청서 작성 가이드 stub."""
+    return {}
+
+
+async def report_writer_node(state: AgentState) -> dict:
+    """최종 보고서 stub."""
+    return {}
+
+
+# ── Checkpointer 팩토리 ──
+
+
+def _build_checkpointer():
+    """환경변수 GRAPH_CHECKPOINTER에 따라 checkpointer를 반환합니다."""
+    mode = os.getenv("GRAPH_CHECKPOINTER", "memory")
+
+    if mode == "sqlite":
+        from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+        db_path = os.getenv("SQLITE_DB_PATH", "./checkpoints.db")
+        return AsyncSqliteSaver.from_conn_string(db_path)
+
+    if mode == "postgres":
+        raise NotImplementedError("Postgres checkpointer is not configured yet.")
+
+    return MemorySaver()
+
+
+# ── 그래프 빌더 ──
+
+
+def build_graph():
+    """StateGraph를 조립하여 컴파일된 그래프를 반환합니다."""
+    builder = StateGraph(AgentState)
+
+    # 노드 등록
+    builder.add_node("initial_interview", initial_interview_node)
+    builder.add_node("rag_search", rag_search_node)
+    builder.add_node("service_select", service_select_node)
+    builder.add_node("rag_detail", rag_detail_node)
+    builder.add_node("detail_interview", detail_interview_node)
+    builder.add_node("document_guidance", document_guidance_node)
+    builder.add_node("draft_writer", draft_writer_node)
+    builder.add_node("report_writer", report_writer_node)
+
+    # 엣지 연결
+    builder.add_edge(START, "initial_interview")
+    builder.add_conditional_edges("initial_interview", route_after_initial_interview)
+    builder.add_conditional_edges("rag_search", route_after_rag_search)
+    builder.add_edge("service_select", "rag_detail")
+    builder.add_edge("rag_detail", "detail_interview")
+    builder.add_conditional_edges("detail_interview", route_after_detail_interview)
+    builder.add_edge("document_guidance", "draft_writer")
+    builder.add_edge("draft_writer", "report_writer")
+    builder.add_edge("report_writer", END)
+
+    checkpointer = _build_checkpointer()
+    return builder.compile(checkpointer=checkpointer)
+
+
+graph = build_graph()

--- a/graph/state.py
+++ b/graph/state.py
@@ -40,11 +40,19 @@ class DisabilitySeverity(StrEnum):
     SEVERE = "중증"
 
 
+class Gender(StrEnum):
+    """성별."""
+
+    MALE = "남성"
+    FEMALE = "여성"
+
+
 class UserProfile(BaseModel):
     """인터뷰로 수집하는 사용자 정보."""
 
     # ── 1단계: RAG 검색 최소 필드 ──
     age: int | None = None
+    gender: Gender | None = None
     region: str | None = None
     household_size: int | None = None
     marital_status: MaritalStatus | None = None

--- a/graph/state.py
+++ b/graph/state.py
@@ -80,7 +80,7 @@ class WelfareCandidate(BaseModel):
     serv_id: str
     serv_nm: str
     serv_dgst: str
-    jur_mnof_nm: str | None = None  # 담당 기관명 — RAG search 응답 추가 요청 예정
+    department: str = ""  # 담당 기관명 — RAG /welfare/search 응답의 "department"
     eligibility_reason: str = ""  # rag_search_node에서 LLM으로 생성
     score: float = 0.0
     priority: int = 0  # rag_search_node가 score 내림차순 정렬 후 부여

--- a/graph/state.py
+++ b/graph/state.py
@@ -40,19 +40,11 @@ class DisabilitySeverity(StrEnum):
     SEVERE = "중증"
 
 
-class Gender(StrEnum):
-    """성별."""
-
-    MALE = "남성"
-    FEMALE = "여성"
-
-
 class UserProfile(BaseModel):
     """인터뷰로 수집하는 사용자 정보."""
 
     # ── 1단계: RAG 검색 최소 필드 ──
     age: int | None = None
-    gender: Gender | None = None
     region: str | None = None
     household_size: int | None = None
     marital_status: MaritalStatus | None = None

--- a/graph/state.py
+++ b/graph/state.py
@@ -53,7 +53,6 @@ class UserProfile(BaseModel):
     disability_severity: DisabilitySeverity | None = None  # disability=True일 때만
     employment_status: EmploymentStatus | None = None
     income_level: IncomeLevel | None = None  # LLM이 대화로 판단, 직접 입력 X
-    pregnant: bool | None = None
 
     @computed_field
     @property

--- a/graph/state.py
+++ b/graph/state.py
@@ -1,0 +1,106 @@
+from enum import StrEnum
+from typing import Annotated
+
+from langchain_core.messages import BaseMessage
+from langgraph.graph.message import add_messages
+from pydantic import BaseModel, computed_field
+from typing_extensions import TypedDict
+
+
+class IncomeLevel(StrEnum):
+    """소득 수준 구분 (RAG 팀 기준 값)."""
+
+    BASIC = "기초수급"
+    NEAR_POOR = "차상위"
+    LOW_INCOME = "저소득"
+    GENERAL = "일반"
+
+
+class EmploymentStatus(StrEnum):
+    """취업 상태."""
+
+    EMPLOYED = "취업"
+    UNEMPLOYED = "실업"
+    INACTIVE = "비경제활동"
+
+
+class MaritalStatus(StrEnum):
+    """혼인 상태."""
+
+    SINGLE = "미혼"
+    MARRIED = "기혼"
+    DIVORCED = "이혼"
+    WIDOWED = "사별"
+
+
+class DisabilitySeverity(StrEnum):
+    """장애 정도."""
+
+    MILD = "경증"
+    SEVERE = "중증"
+
+
+class UserProfile(BaseModel):
+    """인터뷰로 수집하는 사용자 정보."""
+
+    # ── 1단계: RAG 검색 최소 필드 ──
+    age: int | None = None
+    region: str | None = None
+    household_size: int | None = None
+    marital_status: MaritalStatus | None = None
+    has_children: bool | None = None
+    disability: bool | None = None
+    disability_severity: DisabilitySeverity | None = None  # disability=True일 때만
+    employment_status: EmploymentStatus | None = None
+    income_level: IncomeLevel | None = None  # LLM이 대화로 판단, 직접 입력 X
+    pregnant: bool | None = None
+
+    @computed_field
+    @property
+    def is_elderly(self) -> bool | None:
+        """만 65세 이상 여부 (age로 파생)."""
+        return self.age >= 65 if self.age is not None else None
+
+    # ── 2단계: 서비스 특화 필드 ──
+    disability_type: str | None = None
+    disability_grade: str | None = None
+    children_ages: list[int] | None = None
+    housing_type: str | None = None
+    household_type: str | None = None
+    is_veteran: bool | None = None
+    is_single_parent: bool | None = None
+
+    extra_fields: dict[str, str | int | bool] = {}
+
+
+class WelfareCandidate(BaseModel):
+    """RAG 검색 결과로 반환되는 복지 서비스 후보."""
+
+    # ── 1차 RAG 검색 후 채워짐 (필드명 RAG 응답 기준) ──
+    serv_id: str
+    serv_nm: str
+    serv_dgst: str
+    jur_mnof_nm: str | None = None  # 담당 기관명 — RAG search 응답 추가 요청 예정
+    eligibility_reason: str = ""  # rag_search_node에서 LLM으로 생성
+    score: float = 0.0
+    priority: int = 0  # rag_search_node가 score 내림차순 정렬 후 부여
+
+    # ── 2차 RAG 상세 조회 후 채워짐 ──
+    required_documents: list[str] = []
+    application_fields: list[str] = []
+    application_url: str | None = None
+    detail_fetched: bool = False
+
+
+class AgentState(TypedDict):
+    """8개 노드가 공유하는 전체 그래프 상태."""
+
+    messages: Annotated[list[BaseMessage], add_messages]
+    user_profile: UserProfile
+    initial_missing_fields: list[str]
+    welfare_candidates: list[WelfareCandidate]
+    selected_service: WelfareCandidate | None
+    detail_missing_fields: list[str]
+    document_guidance: str
+    application_guide: str
+    final_report: str

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ def run():
         "user_profile": UserProfile(),
         "initial_missing_fields": [
             "age",
+            "gender",
             "region",
             "household_size",
             "marital_status",

--- a/main.py
+++ b/main.py
@@ -1,6 +1,43 @@
+import uuid
+
 from dotenv import load_dotenv
+
+from graph.builder import graph
+from graph.state import UserProfile
 
 load_dotenv()
 
+
+def run():
+    """그래프 실행 진입점."""
+    thread_id = str(uuid.uuid4())
+    config = {"configurable": {"thread_id": thread_id}}
+
+    initial_state = {
+        "messages": [],
+        "user_profile": UserProfile(),
+        "initial_missing_fields": [
+            "age",
+            "region",
+            "household_size",
+            "marital_status",
+            "has_children",
+            "disability",
+            "employment_status",
+            "income_level",
+            "pregnant",
+        ],
+        "welfare_candidates": [],
+        "selected_service": None,
+        "detail_missing_fields": [],
+        "document_guidance": "",
+        "application_guide": "",
+        "final_report": "",
+    }
+
+    result = graph.invoke(initial_state, config)
+    return result
+
+
 if __name__ == "__main__":
-    print("AI agent started")
+    run()

--- a/main.py
+++ b/main.py
@@ -25,7 +25,6 @@ def run():
             "disability",
             "employment_status",
             "income_level",
-            "pregnant",
         ],
         "welfare_candidates": [],
         "selected_service": None,

--- a/main.py
+++ b/main.py
@@ -18,7 +18,6 @@ def run():
         "user_profile": UserProfile(),
         "initial_missing_fields": [
             "age",
-            "gender",
             "region",
             "household_size",
             "marital_status",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ ignore = [
     "B008", # 함수 인자 기본값으로 함수 호출 허용 (FastAPI의 Depends, Query 등 사용을 위해 필수)
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D101", "D102", "D103"]
+
 [tool.ruff.lint.pydocstyle]
 # Docstring 컨벤션을 구글 스타일로 지정
 convention = "google"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,82 @@
+from langgraph.constants import END
+
+from graph.builder import (
+    build_graph,
+    route_after_detail_interview,
+    route_after_initial_interview,
+    route_after_rag_search,
+)
+from graph.state import UserProfile, WelfareCandidate
+
+
+def _make_candidate(**kwargs) -> WelfareCandidate:
+    defaults = dict(
+        serv_id="WLF00000035",
+        serv_nm="기초연금",
+        serv_dgst="노인 연금",
+    )
+    return WelfareCandidate(**{**defaults, **kwargs})
+
+
+def _base_state(**overrides) -> dict:
+    state = {
+        "messages": [],
+        "user_profile": UserProfile(),
+        "initial_missing_fields": [],
+        "welfare_candidates": [],
+        "selected_service": None,
+        "detail_missing_fields": [],
+        "document_guidance": "",
+        "application_guide": "",
+        "final_report": "",
+    }
+    state.update(overrides)
+    return state
+
+
+class TestGraphCompile:
+    def test_graph_compiles(self):
+        g = build_graph()
+        assert g is not None
+
+    def test_all_nodes_registered(self):
+        g = build_graph()
+        nodes = list(g.get_graph().nodes.keys())
+        expected = [
+            "initial_interview",
+            "rag_search",
+            "service_select",
+            "rag_detail",
+            "detail_interview",
+            "document_guidance",
+            "draft_writer",
+            "report_writer",
+        ]
+        for node in expected:
+            assert node in nodes
+
+
+class TestConditionalEdges:
+    def test_initial_interview_rereoutes_when_missing(self):
+        state = _base_state(initial_missing_fields=["age", "region"])
+        assert route_after_initial_interview(state) == "initial_interview"
+
+    def test_initial_interview_proceeds_when_complete(self):
+        state = _base_state(initial_missing_fields=[])
+        assert route_after_initial_interview(state) == "rag_search"
+
+    def test_rag_search_ends_when_no_candidates(self):
+        state = _base_state(welfare_candidates=[])
+        assert route_after_rag_search(state) == END
+
+    def test_rag_search_proceeds_when_candidates_found(self):
+        state = _base_state(welfare_candidates=[_make_candidate()])
+        assert route_after_rag_search(state) == "service_select"
+
+    def test_detail_interview_reentries_when_missing(self):
+        state = _base_state(detail_missing_fields=["household_type"])
+        assert route_after_detail_interview(state) == "detail_interview"
+
+    def test_detail_interview_proceeds_when_complete(self):
+        state = _base_state(detail_missing_fields=[])
+        assert route_after_detail_interview(state) == "document_guidance"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -87,7 +87,7 @@ class TestWelfareCandidate:
         )
         assert candidate.score == 0.0
         assert candidate.priority == 0
-        assert candidate.jur_mnof_nm is None
+        assert candidate.department == ""
         assert candidate.eligibility_reason == ""
         assert candidate.required_documents == []
         assert candidate.application_fields == []

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -105,10 +105,3 @@ class TestWelfareCandidate:
             serv_dgst="노인 연금",
         )
         assert candidate.eligibility_reason == ""
-
-    def test_pregnant_field_exists(self):
-        profile = UserProfile(pregnant=True)
-        assert profile.pregnant is True
-
-    def test_pregnant_default_none(self):
-        assert UserProfile().pregnant is None

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,114 @@
+import pytest
+from pydantic import ValidationError
+
+from graph.state import (
+    DisabilitySeverity,
+    EmploymentStatus,
+    IncomeLevel,
+    MaritalStatus,
+    UserProfile,
+    WelfareCandidate,
+)
+
+
+class TestUserProfile:
+    def test_default_all_none(self):
+        profile = UserProfile()
+        assert profile.age is None
+        assert profile.income_level is None
+        assert profile.disability is None
+
+    def test_is_elderly_true(self):
+        assert UserProfile(age=65).is_elderly is True
+        assert UserProfile(age=66).is_elderly is True
+
+    def test_is_elderly_false(self):
+        assert UserProfile(age=64).is_elderly is False
+
+    def test_is_elderly_none_when_age_missing(self):
+        assert UserProfile().is_elderly is None
+
+    def test_income_level_enum(self):
+        profile = UserProfile(income_level=IncomeLevel.BASIC)
+        assert profile.income_level == "기초수급"
+
+    def test_employment_status_enum(self):
+        profile = UserProfile(employment_status=EmploymentStatus.UNEMPLOYED)
+        assert profile.employment_status == "실업"
+
+    def test_marital_status_enum(self):
+        profile = UserProfile(marital_status=MaritalStatus.SINGLE)
+        assert profile.marital_status == "미혼"
+
+    def test_disability_severity_enum(self):
+        profile = UserProfile(
+            disability=True, disability_severity=DisabilitySeverity.SEVERE
+        )
+        assert profile.disability_severity == "중증"
+
+    def test_disability_severity_only_when_disabled(self):
+        # disability=False면 severity는 None이어야 함
+        profile = UserProfile(disability=False, disability_severity=None)
+        assert profile.disability_severity is None
+
+    def test_extra_fields_default_empty(self):
+        assert UserProfile().extra_fields == {}
+
+    def test_extra_fields_store_values(self):
+        profile = UserProfile(
+            extra_fields={"deposit_amount": 50000000, "vehicle_owned": False}
+        )
+        assert profile.extra_fields["deposit_amount"] == 50000000
+        assert profile.extra_fields["vehicle_owned"] is False
+
+    def test_income_level_all_values(self):
+        values = [e.value for e in IncomeLevel]
+        assert "기초수급" in values
+        assert "차상위" in values
+        assert "저소득" in values
+        assert "일반" in values
+
+
+class TestWelfareCandidate:
+    def test_required_fields(self):
+        candidate = WelfareCandidate(
+            serv_id="WLF00000035",
+            serv_nm="기초연금",
+            serv_dgst="만 65세 이상 저소득 노인 연금",
+        )
+        assert candidate.serv_id == "WLF00000035"
+        assert candidate.serv_nm == "기초연금"
+
+    def test_defaults(self):
+        candidate = WelfareCandidate(
+            serv_id="WLF00000035",
+            serv_nm="기초연금",
+            serv_dgst="노인 연금",
+        )
+        assert candidate.score == 0.0
+        assert candidate.priority == 0
+        assert candidate.jur_mnof_nm is None
+        assert candidate.eligibility_reason == ""
+        assert candidate.required_documents == []
+        assert candidate.application_fields == []
+        assert candidate.application_url is None
+        assert candidate.detail_fetched is False
+
+    def test_missing_required_fields_raises(self):
+        with pytest.raises(ValidationError):
+            WelfareCandidate(serv_id="WLF00000035")
+
+    def test_eligibility_reason_default_empty(self):
+        candidate = WelfareCandidate(
+            serv_id="WLF00000035",
+            serv_nm="기초연금",
+            serv_dgst="노인 연금",
+        )
+        assert candidate.eligibility_reason == ""
+
+    def test_pregnant_field_exists(self):
+        profile = UserProfile(pregnant=True)
+        assert profile.pregnant is True
+
+    def test_pregnant_default_none(self):
+        assert UserProfile().pregnant is None

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 from graph.state import (
     DisabilitySeverity,
     EmploymentStatus,
+    Gender,
     IncomeLevel,
     MaritalStatus,
     UserProfile,
@@ -27,6 +28,13 @@ class TestUserProfile:
 
     def test_is_elderly_none_when_age_missing(self):
         assert UserProfile().is_elderly is None
+
+    def test_gender_enum(self):
+        assert UserProfile(gender=Gender.FEMALE).gender == "여성"
+        assert UserProfile(gender=Gender.MALE).gender == "남성"
+
+    def test_gender_default_none(self):
+        assert UserProfile().gender is None
 
     def test_income_level_enum(self):
         profile = UserProfile(income_level=IncomeLevel.BASIC)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -4,7 +4,6 @@ from pydantic import ValidationError
 from graph.state import (
     DisabilitySeverity,
     EmploymentStatus,
-    Gender,
     IncomeLevel,
     MaritalStatus,
     UserProfile,
@@ -28,13 +27,6 @@ class TestUserProfile:
 
     def test_is_elderly_none_when_age_missing(self):
         assert UserProfile().is_elderly is None
-
-    def test_gender_enum(self):
-        assert UserProfile(gender=Gender.FEMALE).gender == "여성"
-        assert UserProfile(gender=Gender.MALE).gender == "남성"
-
-    def test_gender_default_none(self):
-        assert UserProfile().gender is None
 
     def test_income_level_enum(self):
         profile = UserProfile(income_level=IncomeLevel.BASIC)


### PR DESCRIPTION
## 📝 PR 설명

 - Phase 1 그래프 기반 구축: 상태 모델(state.py), 그래프 빌더(builder.py), 단위 테스트 구현

## 🛠️ 작업 상세 내용

  - `graph/state.py`: AgentState(TypedDict), UserProfile(Pydantic), WelfareCandidate(Pydantic) 구현
  - Enum: IncomeLevel / EmploymentStatus / MaritalStatus / DisabilitySeverity (StrEnum)
  - UserProfile: 1단계 8개 필드 + is_elderly computed_field
  - 2단계 서비스 특화 필드 RAG 팀 문서 기반으로 주석 남김
  - WelfareCandidate: 필드명 RAG 기준으로 통일 (serv_id / serv_nm / serv_dgst)
  - `graph/builder.py`: 8개 stub 노드, 조건부 엣지 3개, GRAPH_CHECKPOINTER 환경변수 기반 checkpointer 팩토리
  - `main.py`: 초기 상태 포함 그래프 실행 진입점
  - `tests/test_state.py` / `tests/test_graph.py`: 총 27개 테스트 작성
  - `CLAUDE.md`: RAG 확정 스펙 반영 및 250줄 → 103줄 압축
  - `.env.example`: GRAPH_CHECKPOINTER, SQLITE_DB_PATH 추가

## 🧪 테스트 여부 및 확인 내용

  - `uv run pytest tests/ -v` → 27 passed

## 📸 스크린샷 (선택)

## 💬 기타 / 참고사항

  - `income_level` 값 (기초수급/차상위/저소득/일반) RAG 팀과 동일한지 확인 필요
  - `required_documents` / `application_fields` 구현 일정 확인 필요
  - SQLite checkpointer 코드 수정 필요 (Phase 5 TODO 5-0 참고)

## 🔗 연관 이슈

- Closes #11
- 해당 PR이 머지되면 이슈가 자동으로 닫힙니다.