### PR TITLE
feat: RAG HTTP 클라이언트 스텁 구현 (Phase 2-0)

### DIFF
--- a/tests/test_rag_client_stub.py
+++ b/tests/test_rag_client_stub.py
@@ -1,0 +1,69 @@
+"""RAG 클라이언트 스텁 인터페이스 계약 검증 테스트."""
+
+from tools.rag_client import get_detail, search
+
+
+class TestSearch:
+    async def test_returns_list(self):
+        result = await search(profile={"age": 65, "income_level": "기초수급"})
+        assert isinstance(result, list)
+
+    async def test_each_item_has_required_fields(self):
+        result = await search(profile={"age": 65, "income_level": "기초수급"})
+        for item in result:
+            assert "serv_id" in item
+            assert "serv_nm" in item
+            assert "serv_dgst" in item
+            assert "department" in item
+            assert "score" in item
+
+    async def test_top_k_limits_results(self):
+        result = await search(profile={"age": 65}, top_k=2)
+        assert len(result) <= 2
+
+    async def test_top_k_default_uses_env(self, monkeypatch):
+        monkeypatch.setenv("RAG_SEARCH_TOP_K", "1")
+        result = await search(profile={"age": 65})
+        assert len(result) <= 1
+
+    async def test_empty_profile_still_returns_list(self):
+        result = await search(profile={})
+        assert isinstance(result, list)
+
+    async def test_score_is_float(self):
+        result = await search(profile={"age": 65})
+        for item in result:
+            assert isinstance(item["score"], float)
+
+
+class TestGetDetail:
+    async def test_returns_dict(self):
+        result = await get_detail("WLF-001")
+        assert isinstance(result, dict)
+
+    async def test_has_required_fields(self):
+        result = await get_detail("WLF-001")
+        assert "serv_id" in result
+        assert "serv_nm" in result
+        assert "required_documents" in result
+        assert "application_fields" in result
+        assert "application_url" in result
+
+    async def test_required_documents_is_list(self):
+        result = await get_detail("WLF-001")
+        assert isinstance(result["required_documents"], list)
+
+    async def test_application_fields_is_list(self):
+        result = await get_detail("WLF-001")
+        assert isinstance(result["application_fields"], list)
+
+    async def test_unknown_service_returns_empty_lists(self):
+        result = await get_detail("UNKNOWN-999")
+        assert result["serv_id"] == "UNKNOWN-999"
+        assert result["required_documents"] == []
+        assert result["application_fields"] == []
+        assert result["application_url"] is None
+
+    async def test_serv_id_matches_requested(self):
+        result = await get_detail("WLF-002")
+        assert result["serv_id"] == "WLF-002"

--- a/tools/rag_client.py
+++ b/tools/rag_client.py
@@ -1,0 +1,119 @@
+"""RAG 서비스 HTTP 클라이언트.
+
+Phase 2: 하드코딩 더미 데이터 반환 스텁.
+Phase 3: 실제 httpx.AsyncClient 연동으로 교체.
+"""
+
+import os
+
+
+async def search(profile: dict, top_k: int | None = None) -> list[dict]:
+    """복지 서비스 후보 목록 검색.
+
+    Args:
+        profile: UserProfile 핵심 필드를 담은 flat dict (age, income_level 등)
+        top_k: 반환할 최대 후보 수. None이면 RAG_SEARCH_TOP_K 환경변수 사용 (기본 5)
+
+    Returns:
+        [{"serv_id", "serv_nm", "serv_dgst", "department", "score"}, ...]
+        결과 없으면 빈 리스트 반환.
+    """
+    if top_k is None:
+        top_k = int(os.getenv("RAG_SEARCH_TOP_K", "5"))
+
+    # Phase 3에서 실제 HTTP 연동으로 교체
+    return [
+        {
+            "serv_id": "WLF-001",
+            "serv_nm": "기초생활수급자 생계급여",
+            "serv_dgst": (
+                "생활이 어려운 기초생활수급자에게 생계에 필요한 급여를 지급합니다."
+            ),
+            "department": "보건복지부",
+            "score": 0.95,
+        },
+        {
+            "serv_id": "WLF-002",
+            "serv_nm": "장애인 활동지원 서비스",
+            "serv_dgst": (
+                "장애인의 자립생활을 지원하기 위해 활동보조, 방문목욕 등을 제공합니다."
+            ),
+            "department": "보건복지부",
+            "score": 0.87,
+        },
+        {
+            "serv_id": "WLF-003",
+            "serv_nm": "노인 돌봄 종합서비스",
+            "serv_dgst": (
+                "혼자 힘으로 일상생활을 영위하기 어려운 노인에게 "
+                "가사·활동지원 서비스를 제공합니다."
+            ),
+            "department": "보건복지부",
+            "score": 0.80,
+        },
+    ][:top_k]
+
+
+async def get_detail(service_id: str) -> dict:
+    """특정 복지 서비스 상세 정보 조회.
+
+    Args:
+        service_id: RAG 서비스 ID (WelfareCandidate.serv_id)
+
+    Returns:
+        {"serv_id", "serv_nm", "required_documents", "application_fields",
+        "application_url", ...}
+    """
+    # Phase 3에서 실제 HTTP 연동으로 교체
+    dummy_details = {
+        "WLF-001": {
+            "serv_id": "WLF-001",
+            "serv_nm": "기초생활수급자 생계급여",
+            "required_documents": [
+                "사회보장급여 신청서",
+                "신분증",
+                "금융정보 제공 동의서",
+            ],
+            "application_fields": [
+                "신청인 성명",
+                "생년월일",
+                "주소",
+                "소득 수준",
+                "가구원 수",
+            ],
+            "application_url": "https://www.bokjiro.go.kr",
+        },
+        "WLF-002": {
+            "serv_id": "WLF-002",
+            "serv_nm": "장애인 활동지원 서비스",
+            "required_documents": [
+                "장애인 활동지원 신청서",
+                "장애인 등록증",
+                "건강보험료 납부 확인서",
+            ],
+            "application_fields": [
+                "신청인 성명",
+                "장애 유형",
+                "장애 등급",
+                "활동지원 필요 사유",
+            ],
+            "application_url": "https://www.ableservice.or.kr",
+        },
+        "WLF-003": {
+            "serv_id": "WLF-003",
+            "serv_nm": "노인 돌봄 종합서비스",
+            "required_documents": ["서비스 신청서", "신분증", "건강보험료 납부 확인서"],
+            "application_fields": ["신청인 성명", "생년월일", "주소", "돌봄 필요 사유"],
+            "application_url": "https://www.longtermcare.or.kr",
+        },
+    }
+    return dummy_details.get(
+        service_id,
+        {
+            "serv_id": service_id,
+            "serv_nm": "알 수 없는 서비스",
+            "required_documents": [],
+            "application_fields": [],
+            "application_url": None,
+        },
+    )


### PR DESCRIPTION
  ## 📝 PR 설명

  - 에이전트 노드들이 RAG 서버를 호출할 때 사용할 `tools/rag_client.py` 인터페이스를 정의하고 스텁으로 구현합니다.

  ## 🛠️ 작업 상세 내용

  - `tools/rag_client.py` — `search()` / `get_detail()` 두 함수 스텁 구현 (더미 데이터 반환)
  - `search(profile, top_k)` — UserProfile 정보를 받아 복지 서비스 후보 목록 반환                                                                                                    
  - `get_detail(service_id)` — 서비스 ID로 필요 서류·신청 항목·URL 등 상세 정보 반환
  - `tests/test_rag_client_stub.py` — 인터페이스 계약 검증 테스트 12개 작성                                                                                                          
                                                                                                                                                                                     
  ## 🧪 테스트 여부 및 확인 내용                                                                                                                                                     
                                                                                                                                                                                     
  - `uv run pytest tests/test_rag_client_stub.py` 12개 통과                                                                                                                          
  - 전체 테스트(`uv run pytest tests/`) 37개 통과 (기존 테스트 회귀 없음)                                                                                                            
                                                                         
  ## 📸 스크린샷 (선택)                                                                                                                                                              
                                                            
  ## 💬 기타 / 참고사항                                                                                                                                                              
                                                            
  - Phase 2에서는 하드코딩 더미 데이터 반환, Phase 3에서 실제 `httpx.AsyncClient` 연동으로 교체 예정
  - 에이전트 노드에서 `httpx` 직접 호출 금지 — 반드시 이 클라이언트를 통해서만 호출                                                                                                  
                                                                                   
  ## 🔗 연관 이슈                                                                                                                                                                    
                                                                                                                                                                                     
  - Closes #15 
