### PR TITLE
feat: RAG 검색 노드 구현 (Phase 2-2)

### DIFF
--- a/agents/rag_search.py
+++ b/agents/rag_search.py
@@ -1,0 +1,104 @@
+"""RAG 검색 노드 — UserProfile로 복지 서비스 후보 목록 조회."""
+
+import os
+
+from langchain_core.messages import AIMessage
+
+import tools.rag_client as rag_client
+from graph.state import AgentState, UserProfile, WelfareCandidate
+from tools.llm import get_llm
+
+
+def _profile_to_dict(profile: UserProfile) -> dict:
+    """UserProfile 최소 필드를 RAG 전송용 flat dict로 변환."""
+    data = {}
+    if profile.age is not None:
+        data["age"] = profile.age
+    if profile.income_level is not None:
+        data["income_level"] = profile.income_level.value
+    if profile.disability is not None:
+        data["disability"] = profile.disability
+    if profile.disability_severity is not None:
+        data["disability_severity"] = profile.disability_severity.value
+    if profile.employment_status is not None:
+        data["employment_status"] = profile.employment_status.value
+    if profile.region is not None:
+        data["region"] = profile.region
+    if profile.is_elderly is not None:
+        data["is_elderly"] = profile.is_elderly
+    return data
+
+
+def _generate_eligibility_reason(
+    llm, serv_nm: str, serv_dgst: str, profile: UserProfile
+) -> str:
+    """서비스 요약과 사용자 프로필을 기반으로 선정 이유를 생성."""
+    prompt = (
+        f"다음 복지 서비스가 이 사용자에게 적합한 이유를 한 문장으로 설명하세요.\n\n"
+        f"서비스명: {serv_nm}\n"
+        f"서비스 요약: {serv_dgst}\n"
+        f"사용자 정보: 나이 {profile.age}세, 지역 {profile.region}, "
+        f"소득수준 {profile.income_level}"
+    )
+    try:
+        response = llm.invoke(prompt)
+        return response.content
+    except Exception:
+        return ""
+
+
+async def rag_search_node(state: AgentState) -> dict:
+    """RAG 후보 검색 노드 — UserProfile → WelfareCandidate 리스트."""
+    profile: UserProfile = state["user_profile"]
+    top_k = int(os.getenv("RAG_SEARCH_TOP_K", "5"))
+
+    # RAG 호출 (1회 재시도)
+    results = None
+    for _ in range(2):
+        try:
+            results = await rag_client.search(
+                profile=_profile_to_dict(profile), top_k=top_k
+            )
+            break
+        except Exception:
+            continue
+
+    if results is None:
+        error_msg = (
+            "죄송합니다. 복지 서비스 검색 중 연결 오류가 발생했습니다. "
+            "잠시 후 다시 시도해 주세요."
+        )
+        return {
+            "welfare_candidates": [],
+            "messages": [AIMessage(content=error_msg)],
+        }
+
+    if not results:
+        no_result_msg = "입력하신 정보로 해당하는 복지 서비스를 찾지 못했습니다."
+        return {
+            "welfare_candidates": [],
+            "messages": [AIMessage(content=no_result_msg)],
+        }
+
+    # score 내림차순 정렬
+    results.sort(key=lambda x: x.get("score", 0.0), reverse=True)
+
+    llm = get_llm()
+    candidates = []
+    for priority, item in enumerate(results, start=1):
+        eligibility_reason = _generate_eligibility_reason(
+            llm, item["serv_nm"], item["serv_dgst"], profile
+        )
+        candidates.append(
+            WelfareCandidate(
+                serv_id=item["serv_id"],
+                serv_nm=item["serv_nm"],
+                serv_dgst=item["serv_dgst"],
+                department=item.get("department", ""),
+                score=item.get("score", 0.0),
+                priority=priority,
+                eligibility_reason=eligibility_reason,
+            )
+        )
+
+    return {"welfare_candidates": candidates}

--- a/graph/builder.py
+++ b/graph/builder.py
@@ -5,6 +5,7 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.constants import END, START
 from langgraph.graph import StateGraph
 
+from agents.rag_search import rag_search_node
 from graph.state import AgentState
 
 load_dotenv()
@@ -39,11 +40,6 @@ def route_after_detail_interview(state: AgentState) -> str:
 
 async def initial_interview_node(state: AgentState) -> dict:
     """1단계 인터뷰 stub."""
-    return {}
-
-
-async def rag_search_node(state: AgentState) -> dict:
-    """RAG 후보 검색 stub."""
     return {}
 
 

--- a/tests/test_rag_search.py
+++ b/tests/test_rag_search.py
@@ -1,0 +1,164 @@
+"""RAG 검색 노드 테스트."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.messages import AIMessage
+
+from agents.rag_search import _profile_to_dict, rag_search_node
+from graph.state import (
+    AgentState,
+    EmploymentStatus,
+    IncomeLevel,
+    UserProfile,
+    WelfareCandidate,
+)
+
+
+def _make_state(**kwargs) -> AgentState:
+    defaults = {
+        "messages": [],
+        "user_profile": UserProfile(
+            age=65,
+            income_level=IncomeLevel.BASIC,
+            disability=False,
+            employment_status=EmploymentStatus.INACTIVE,
+            region="서울",
+        ),
+        "initial_missing_fields": [],
+        "welfare_candidates": [],
+        "selected_service": None,
+        "detail_missing_fields": [],
+        "document_guidance": "",
+        "application_guide": "",
+        "final_report": "",
+    }
+    defaults.update(kwargs)
+    return defaults  # type: ignore[return-value]
+
+
+_DUMMY_RAG_RESULTS = [
+    {
+        "serv_id": "WLF-001",
+        "serv_nm": "기초생활수급자 생계급여",
+        "serv_dgst": "생활이 어려운 기초생활수급자에게 급여를 지급합니다.",
+        "department": "보건복지부",
+        "score": 0.95,
+    },
+    {
+        "serv_id": "WLF-002",
+        "serv_nm": "노인 돌봄 서비스",
+        "serv_dgst": "혼자 생활하기 어려운 노인에게 돌봄 서비스를 제공합니다.",
+        "department": "보건복지부",
+        "score": 0.80,
+    },
+]
+
+
+class TestProfileToDict:
+    def test_includes_filled_fields_only(self):
+        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, region="서울")
+        result = _profile_to_dict(profile)
+        assert result["age"] == 65
+        assert result["income_level"] == "기초수급"
+        assert result["region"] == "서울"
+
+    def test_excludes_none_fields(self):
+        profile = UserProfile(age=40)
+        result = _profile_to_dict(profile)
+        assert "income_level" not in result
+        assert "disability" not in result
+
+    def test_includes_is_elderly_derived_field(self):
+        profile = UserProfile(age=65)
+        result = _profile_to_dict(profile)
+        assert result["is_elderly"] is True
+
+    def test_enum_values_are_strings(self):
+        profile = UserProfile(
+            employment_status=EmploymentStatus.UNEMPLOYED,
+            income_level=IncomeLevel.NEAR_POOR,
+        )
+        result = _profile_to_dict(profile)
+        assert result["employment_status"] == "실업"
+        assert result["income_level"] == "차상위"
+
+
+class TestRagSearchNode:
+    @patch("agents.rag_search.get_llm")
+    @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
+    async def test_returns_candidates_on_success(self, mock_search, mock_get_llm):
+        mock_search.return_value = _DUMMY_RAG_RESULTS
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="해당 서비스 대상자입니다.")
+        mock_get_llm.return_value = mock_llm
+
+        result = await rag_search_node(_make_state())
+
+        assert len(result["welfare_candidates"]) == 2
+        assert all(
+            isinstance(c, WelfareCandidate) for c in result["welfare_candidates"]
+        )
+
+    @patch("agents.rag_search.get_llm")
+    @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
+    async def test_priority_assigned_by_score_order(self, mock_search, mock_get_llm):
+        unsorted = [
+            {**_DUMMY_RAG_RESULTS[1], "score": 0.80},
+            {**_DUMMY_RAG_RESULTS[0], "score": 0.95},
+        ]
+        mock_search.return_value = unsorted
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="")
+        mock_get_llm.return_value = mock_llm
+
+        result = await rag_search_node(_make_state())
+
+        candidates = result["welfare_candidates"]
+        assert candidates[0].priority == 1
+        assert candidates[0].score == 0.95
+        assert candidates[1].priority == 2
+        assert candidates[1].score == 0.80
+
+    @patch("agents.rag_search.get_llm")
+    @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
+    async def test_empty_result_returns_no_candidates_with_message(
+        self, mock_search, mock_get_llm
+    ):
+        mock_search.return_value = []
+        mock_get_llm.return_value = MagicMock()
+
+        result = await rag_search_node(_make_state())
+
+        assert result["welfare_candidates"] == []
+        assert isinstance(result["messages"][0], AIMessage)
+        assert "찾지 못했습니다" in result["messages"][0].content
+
+    @patch("agents.rag_search.get_llm")
+    @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
+    async def test_network_error_retries_and_returns_error_message(
+        self, mock_search, mock_get_llm
+    ):
+        mock_search.side_effect = Exception("Connection error")
+        mock_get_llm.return_value = MagicMock()
+
+        result = await rag_search_node(_make_state())
+
+        assert result["welfare_candidates"] == []
+        assert isinstance(result["messages"][0], AIMessage)
+        assert "연결 오류" in result["messages"][0].content
+        assert mock_search.call_count == 2  # 1회 재시도 확인
+
+    @patch("agents.rag_search.get_llm")
+    @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
+    async def test_eligibility_reason_generated_per_candidate(
+        self, mock_search, mock_get_llm
+    ):
+        mock_search.return_value = _DUMMY_RAG_RESULTS
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="적합한 서비스입니다.")
+        mock_get_llm.return_value = mock_llm
+
+        result = await rag_search_node(_make_state())
+
+        for candidate in result["welfare_candidates"]:
+            assert candidate.eligibility_reason != ""


### PR DESCRIPTION
  ## 📝 PR 설명                                             
               
  - UserProfile을 RAG에 전달하여 복지 서비스 후보 목록을 조회하고 WelfareCandidate 리스트로 변환하는 rag_search 노드를 구현합니다.                                                   
                                                                                                                                                                                     
  ## 🛠️  작업 상세 내용                                                                                                                                                               
                                                                                                                                                                                     
  - `agents/rag_search.py` — `rag_client.search()` 호출 및 WelfareCandidate 변환
  - UserProfile 최소 필드를 flat JSON으로 직렬화하여 전송                                                                                                                            
  - score 내림차순 정렬 후 priority 부여, 상위 N개 반환     
  - RAG 결과 빈 목록 → 사용자 안내 후 그래프 종료 (LLM 폴백 없음)                                                                                                                    
  - 네트워크 오류 시 1회 재시도 후 "서비스 연결 실패" 안내 및 종료                                                                                                                   
  - `graph/builder.py` stub 노드를 실제 구현으로 교체                                                                                                                                
  - `tests/test_rag_search.py` — 9개 테스트 작성                                                                                                                                     
                                                                                                                                                                                     
  ## 🧪 테스트 여부 및 확인 내용                                                                                                                                                     
                                                                                                                                                                                     
  - `uv run pytest tests/test_rag_search.py` 9개 통과                                                                                                                                
  - 전체 테스트(`uv run pytest tests/`) 46개 통과                                                                                                                                    
                                                 
  ## 📸 스크린샷 (선택)                                                                                                                                                              
                                                            
  ## 💬 기타 / 참고사항                                                                                                                                                              
                                                                                                                                                                                     
  - httpx 직접 호출 없이 `tools/rag_client.py`를 통해서만 RAG 호출
  - RAG 결과 없음 시 LLM 폴백 없이 종료 (복지 서비스 임의 생성 금지)                                                                                                                 
                                                                    
  ## 🔗 연관 이슈                                                                                                                                                                    
                                                                                                                                                                                     
  - 이슈 닫지 않음 (epic/phase2 → develop 최종 PR 시 일괄 Close 예정)