### PR TITLE
feat: migrate initial_interview to hwnv.cloud API

### DIFF
--- a/agents/initial_interview.py
+++ b/agents/initial_interview.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.types import interrupt
-from pydantic import BaseModel
 
-# Pydantic 모델 필드 타입으로 런타임에 필요 — TYPE_CHECKING 블록으로 이동 불가
 from graph.state import (  # noqa: TCH001
     DisabilitySeverity,
     EmploymentStatus,
@@ -16,148 +14,94 @@ from graph.state import (  # noqa: TCH001
     MaritalStatus,
     UserProfile,
 )
-from tools.llm import get_llm
-from tools.prompt_loader import load_prompt
+from tools import hwnv_client
 
 if TYPE_CHECKING:
     from graph.state import AgentState
 
-_FIELD_LABELS: dict[str, str] = {
-    "age": "나이",
-    "region": "거주 지역",
-    "household_size": "가구원 수",
-    "marital_status": "혼인 상태",
-    "has_children": "자녀 유무",
-    "disability": "장애 여부",
-    "disability_severity": "장애 정도(경증/중증)",
-    "employment_status": "취업 상태",
-    "income_level": "소득 수준",
+_VALUE_CONVERTERS: dict = {
+    "age": int,
+    "region": str,
+    "household_size": int,
+    "marital_status": MaritalStatus,
+    "has_children": bool,
+    "disability": bool,
+    "disability_severity": DisabilitySeverity,
+    "employment_status": EmploymentStatus,
+    "income_level": IncomeLevel,
 }
 
-_MAX_RETRY = 2
+
+def _apply_value(profile: UserProfile, field: str, raw_value) -> UserProfile:
+    """추출된 원시 값을 올바른 타입으로 변환해 프로필에 적용합니다."""
+    converter = _VALUE_CONVERTERS.get(field)
+    value = converter(raw_value) if converter else raw_value
+    return profile.model_copy(update={field: value})
 
 
-class _ProfileExtraction(BaseModel):
-    """structured output 스키마: 대화에서 추출된 1단계 프로필 필드."""
-
-    age: int | None = None
-    region: str | None = None
-    household_size: int | None = None
-    marital_status: MaritalStatus | None = None
-    has_children: bool | None = None
-    disability: bool | None = None
-    disability_severity: DisabilitySeverity | None = None
-    employment_status: EmploymentStatus | None = None
-    income_level: IncomeLevel | None = None
-
-
-async def _generate_question(
+def _update_missing(
+    collected_field: str,
     profile: UserProfile,
     missing: list[str],
-    history: list,
-) -> str:
-    """누락 필드에 대한 자연스러운 인터뷰 질문을 생성합니다."""
-    system_prompt = load_prompt("initial_interview")
-    missing_labels = [_FIELD_LABELS.get(f, f) for f in missing]
-    collected = {
-        k: v
-        for k, v in profile.model_dump(exclude_none=True).items()
-        if k not in ("is_elderly", "extra_fields")
-    }
+) -> list[str]:
+    """수집 완료된 필드를 제거하고 disability 특수 케이스를 처리합니다."""
+    new_missing = [f for f in missing if f != collected_field]
 
-    instruction = (
-        f"[시스템] 아직 수집하지 못한 정보: {', '.join(missing_labels)}\n"
-        f"[시스템] 현재까지 파악된 정보: {collected}"
-    )
-    messages = [
-        SystemMessage(content=system_prompt),
-        *history,
-        HumanMessage(content=instruction),
-    ]
-    response = await get_llm().ainvoke(messages)
-    return response.content
-
-
-async def _extract_profile(
-    profile: UserProfile,
-    missing: list[str],
-    user_answer: str,
-    history: list,
-) -> tuple[UserProfile, list[str]]:
-    """사용자 답변에서 프로필 필드를 추출합니다. 실패 시 최대 2회 재시도.
-
-    파싱 실패가 모든 재시도에서 발생하면 기존 profile과 missing을 그대로 반환합니다.
-    """
-    extract_system = (
-        "사용자의 답변에서 복지 서비스 신청용 개인 정보를 추출하세요.\n"
-        "확실하지 않은 값은 null로 두세요. 추론하거나 가정하지 마세요.\n"
-        f"추출 대상 필드: {', '.join(missing)}"
-    )
-    messages = [
-        SystemMessage(content=extract_system),
-        *history,
-        HumanMessage(content=user_answer),
-    ]
-
-    extractor = get_llm().with_structured_output(_ProfileExtraction)
-    extraction: _ProfileExtraction | None = None
-    for _ in range(_MAX_RETRY + 1):
-        try:
-            extraction = await extractor.ainvoke(messages)
-            break
-        except Exception:
-            continue
-
-    if extraction is None:
-        return profile, missing
-
-    updates = {k: v for k, v in extraction.model_dump().items() if v is not None}
-    new_profile = profile.model_copy(update=updates)
-
-    # 장애 없음 확정 시 severity 필드 초기화
-    if new_profile.disability is False:
-        new_profile = new_profile.model_copy(update={"disability_severity": None})
-
-    new_missing: list[str] = []
-    for field in missing:
-        if field == "disability_severity" and new_profile.disability is False:
-            continue
-        if getattr(new_profile, field, None) is None:
-            new_missing.append(field)
-
-    # 장애 있음으로 확인됐는데 severity 미수집이면 missing에 추가
-    if (
-        new_profile.disability is True
-        and new_profile.disability_severity is None
+    if profile.disability is False:
+        new_missing = [f for f in new_missing if f != "disability_severity"]
+    elif (
+        profile.disability is True
+        and profile.disability_severity is None
         and "disability_severity" not in new_missing
     ):
         new_missing.append("disability_severity")
 
-    return new_profile, new_missing
+    return new_missing
 
 
 async def initial_interview_node(state: AgentState) -> dict:
-    """1단계 인터뷰: 최소 사용자 정보를 수집하여 RAG 검색 기반을 마련합니다."""
-    profile = state["user_profile"]
+    """1단계 인터뷰: hwnv.cloud API로 필드별 질문·추출을 수행합니다."""
     missing = list(state["initial_missing_fields"])
-
     if not missing:
         return {}
 
-    question = await _generate_question(profile, missing, list(state["messages"]))
-    ai_message = AIMessage(content=question)
+    current_field: str | None = state.get("interview_current_field")
+    is_reask = current_field is not None
+    field = current_field or missing[0]
 
-    user_answer: str = interrupt({"question": question, "missing_fields": missing})
-
-    new_profile, new_missing = await _extract_profile(
-        profile,
-        missing,
-        user_answer,
-        list(state["messages"]) + [ai_message],
+    question = await hwnv_client.ask_question(
+        field=field,
+        re_ask=is_reask,
+        pre_assistant_message=state.get("interview_last_question", "")
+        if is_reask
+        else "",
+        pre_user_message=state.get("interview_last_answer", "") if is_reask else "",
     )
 
+    user_answer: str = interrupt({"question": question, "field": field})
+
+    result = await hwnv_client.extract_value(field, question, user_answer)
+
+    ai_msg = AIMessage(content=question)
+    human_msg = HumanMessage(content=user_answer)
+
+    if result.get("exist"):
+        new_profile = _apply_value(state["user_profile"], field, result["value"])
+        new_missing = _update_missing(field, new_profile, missing)
+        return {
+            "messages": [ai_msg, human_msg],
+            "user_profile": new_profile,
+            "initial_missing_fields": new_missing,
+            "interview_current_field": None,
+            "interview_last_question": "",
+            "interview_last_answer": "",
+        }
+
+    # 추출 실패 또는 재질문 필요 → 다음 호출에서 re_ask=True로 재진입
     return {
-        "messages": [ai_message, HumanMessage(content=user_answer)],
-        "user_profile": new_profile,
-        "initial_missing_fields": new_missing,
+        "messages": [ai_msg, human_msg],
+        "initial_missing_fields": missing,
+        "interview_current_field": field,
+        "interview_last_question": question,
+        "interview_last_answer": user_answer,
     }

--- a/graph/state.py
+++ b/graph/state.py
@@ -103,3 +103,7 @@ class AgentState(TypedDict):
     document_guidance: str
     application_guide: str
     final_report: str
+    # 1단계 인터뷰 재질문 추적 (hwnv_client re_ask 흐름용)
+    interview_current_field: str | None  # 현재 처리 중인 필드 (None=새 필드)
+    interview_last_question: str  # 직전 봇 질문 (re_ask pre_assistant_message)
+    interview_last_answer: str  # 직전 사용자 답변 (re_ask pre_user_message)

--- a/main.py
+++ b/main.py
@@ -32,6 +32,9 @@ def run():
         "document_guidance": "",
         "application_guide": "",
         "final_report": "",
+        "interview_current_field": None,
+        "interview_last_question": "",
+        "interview_last_answer": "",
     }
 
     result = graph.invoke(initial_state, config)

--- a/test_live.py
+++ b/test_live.py
@@ -1,0 +1,85 @@
+"""hwnv.cloud API 실시간 테스트 — 자동 답변 모드."""
+
+import asyncio
+
+from tools.hwnv_client import ask_question, extract_value
+
+# 필드별 자동 답변 (원하는 값으로 수정하세요)
+AUTO_ANSWERS: dict[str, str] = {
+    "age": "저는 26살이에요",
+    "region": "수원시에 살아요",
+    "household_size": "3명이요",
+    "marital_status": "미혼입니다",
+    "has_children": "자녀 없어요",
+    "disability": "장애 없습니다",
+    "disability_severity": "경증이에요",
+    "employment_status": "취업 중이에요",
+    "income_level": "일반 소득이에요",
+}
+
+FIELDS = [
+    "age",
+    "region",
+    "household_size",
+    "marital_status",
+    "has_children",
+    "disability",
+    "employment_status",
+    "income_level",
+]
+
+
+async def interview_field(field: str) -> tuple[str, object]:
+    """단일 필드에 대해 질문-답변-추출 루프를 수행합니다."""
+    last_question = ""
+    last_answer = ""
+    is_reask = False
+
+    while True:
+        question = await ask_question(
+            field=field,
+            re_ask=is_reask,
+            pre_assistant_message=last_question if is_reask else "",
+            pre_user_message=last_answer if is_reask else "",
+        )
+
+        user_answer = AUTO_ANSWERS[field]
+        print(f"\n[{field}] {question}")
+        print(f"  >> {user_answer}  (자동)")
+
+        result = await extract_value(field, question, user_answer)
+        print(
+            f"  exist={result['exist']}, value={result['value']},"
+            f" re_ask={result['re_ask']}"
+        )
+        print(f"  reasoning: {result['reasoning']}")
+
+        if result["exist"]:
+            return field, result["value"]
+
+        last_question = question
+        last_answer = user_answer
+        is_reask = True
+
+
+async def main() -> None:
+    """모든 인터뷰 필드에 대해 hwnv.cloud API 질문·추출 흐름을 자동으로 테스트합니다."""
+    print("=== hwnv.cloud API 자동 테스트 ===\n")
+
+    collected: dict = {}
+
+    for field in FIELDS:
+        key, value = await interview_field(field)
+        collected[key] = value
+
+        if field == "disability" and value is True:
+            key2, value2 = await interview_field("disability_severity")
+            collected[key2] = value2
+
+    print("\n=== 수집 결과 ===")
+    for k, v in collected.items():
+        print(f"  {k}: {v}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_initial_interview.py
+++ b/tests/test_initial_interview.py
@@ -1,16 +1,15 @@
 """1단계 인터뷰 에이전트 테스트."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from langchain_core.messages import AIMessage, HumanMessage
 
 from agents.initial_interview import (
-    _extract_profile,
-    _generate_question,
-    _ProfileExtraction,
+    _apply_value,
+    _update_missing,
     initial_interview_node,
 )
-from graph.state import DisabilitySeverity, UserProfile
+from graph.state import DisabilitySeverity, MaritalStatus, UserProfile
 
 
 def _base_state(**overrides) -> dict:
@@ -30,6 +29,9 @@ def _base_state(**overrides) -> dict:
         "document_guidance": "",
         "application_guide": "",
         "final_report": "",
+        "interview_current_field": None,
+        "interview_last_question": "",
+        "interview_last_answer": "",
     }
     state.update(overrides)
     return state
@@ -41,36 +43,61 @@ class TestInitialInterviewNodeBasic:
         result = await initial_interview_node(state)
         assert result == {}
 
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
     @patch("agents.initial_interview.interrupt", return_value="저는 40살이에요")
-    @patch("agents.initial_interview.load_prompt", return_value="system prompt")
-    @patch("agents.initial_interview.get_llm")
-    async def test_interrupts_with_question(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
+    async def test_first_call_uses_reask_false(
+        self, mock_interrupt, mock_ask, mock_extract
     ):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_ProfileExtraction(age=40)
-        )
+        mock_ask.return_value = "나이가 어떻게 되세요?"
+        mock_extract.return_value = {
+            "exist": True,
+            "value": 40,
+            "re_ask": False,
+            "reasoning": "",
+        }
 
         state = _base_state(initial_missing_fields=["age"])
         await initial_interview_node(state)
 
-        mock_interrupt.assert_called_once()
-        call_args = mock_interrupt.call_args[0][0]
-        assert "question" in call_args
-        assert "missing_fields" in call_args
-        assert "age" in call_args["missing_fields"]
-
-    @patch("agents.initial_interview.interrupt", return_value="저는 40살이에요")
-    @patch("agents.initial_interview.load_prompt", return_value="system prompt")
-    @patch("agents.initial_interview.get_llm")
-    async def test_messages_contain_ai_and_human(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_ProfileExtraction(age=40)
+        mock_ask.assert_called_once_with(
+            field="age", re_ask=False, pre_assistant_message="", pre_user_message=""
         )
+
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
+    @patch("agents.initial_interview.interrupt", return_value="저는 40살이에요")
+    async def test_interrupts_with_question_and_field(
+        self, mock_interrupt, mock_ask, mock_extract
+    ):
+        mock_ask.return_value = "나이가 어떻게 되세요?"
+        mock_extract.return_value = {
+            "exist": True,
+            "value": 40,
+            "re_ask": False,
+            "reasoning": "",
+        }
+
+        state = _base_state(initial_missing_fields=["age"])
+        await initial_interview_node(state)
+
+        call_args = mock_interrupt.call_args[0][0]
+        assert call_args["question"] == "나이가 어떻게 되세요?"
+        assert call_args["field"] == "age"
+
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
+    @patch("agents.initial_interview.interrupt", return_value="저는 40살이에요")
+    async def test_messages_contain_ai_and_human(
+        self, mock_interrupt, mock_ask, mock_extract
+    ):
+        mock_ask.return_value = "나이가 어떻게 되세요?"
+        mock_extract.return_value = {
+            "exist": True,
+            "value": 40,
+            "re_ask": False,
+            "reasoning": "",
+        }
 
         state = _base_state(initial_missing_fields=["age"])
         result = await initial_interview_node(state)
@@ -84,70 +111,157 @@ class TestInitialInterviewNodeBasic:
 
 
 class TestInitialInterviewNodeExtraction:
-    @patch("agents.initial_interview.interrupt", return_value="서울, 40살")
-    @patch("agents.initial_interview.load_prompt", return_value="system prompt")
-    @patch("agents.initial_interview.get_llm")
-    async def test_extracted_fields_removed_from_missing(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
+    @patch("agents.initial_interview.interrupt", return_value="40살이에요")
+    async def test_extracted_field_removed_from_missing(
+        self, mock_interrupt, mock_ask, mock_extract
     ):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_ProfileExtraction(age=40, region="서울")
-        )
+        mock_ask.return_value = "나이가 어떻게 되세요?"
+        mock_extract.return_value = {
+            "exist": True,
+            "value": 40,
+            "re_ask": False,
+            "reasoning": "",
+        }
 
         state = _base_state(initial_missing_fields=["age", "region", "income_level"])
         result = await initial_interview_node(state)
 
         assert "age" not in result["initial_missing_fields"]
-        assert "region" not in result["initial_missing_fields"]
+        assert "region" in result["initial_missing_fields"]
         assert "income_level" in result["initial_missing_fields"]
 
-    @patch("agents.initial_interview.interrupt", return_value="서울, 40살")
-    @patch("agents.initial_interview.load_prompt", return_value="system prompt")
-    @patch("agents.initial_interview.get_llm")
-    async def test_profile_updated_with_extracted_fields(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
+    @patch("agents.initial_interview.interrupt", return_value="40살이에요")
+    async def test_profile_updated_with_extracted_value(
+        self, mock_interrupt, mock_ask, mock_extract
     ):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_ProfileExtraction(age=40, region="서울")
-        )
+        mock_ask.return_value = "나이가 어떻게 되세요?"
+        mock_extract.return_value = {
+            "exist": True,
+            "value": 40,
+            "re_ask": False,
+            "reasoning": "",
+        }
+
+        state = _base_state(initial_missing_fields=["age"])
+        result = await initial_interview_node(state)
+
+        assert result["user_profile"].age == 40
+
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
+    @patch("agents.initial_interview.interrupt", return_value="잘 모르겠어요")
+    async def test_extraction_failure_keeps_missing_and_sets_current_field(
+        self, mock_interrupt, mock_ask, mock_extract
+    ):
+        mock_ask.return_value = "나이가 어떻게 되세요?"
+        mock_extract.return_value = {
+            "exist": False,
+            "value": None,
+            "re_ask": True,
+            "reasoning": "불명확",
+        }
 
         state = _base_state(initial_missing_fields=["age", "region"])
         result = await initial_interview_node(state)
 
-        profile = result["user_profile"]
-        assert profile.age == 40
-        assert profile.region == "서울"
+        assert "age" in result["initial_missing_fields"]
+        assert result["interview_current_field"] == "age"
+        assert result["interview_last_question"] == "나이가 어떻게 되세요?"
+        assert result["interview_last_answer"] == "잘 모르겠어요"
+
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
+    @patch("agents.initial_interview.interrupt", return_value="스물여섯이요")
+    async def test_reask_entry_uses_reask_true_with_pre_messages(
+        self, mock_interrupt, mock_ask, mock_extract
+    ):
+        mock_ask.return_value = "조금 더 구체적으로 말씀해주실 수 있나요?"
+        mock_extract.return_value = {
+            "exist": True,
+            "value": 26,
+            "re_ask": False,
+            "reasoning": "",
+        }
+
+        state = _base_state(
+            initial_missing_fields=["age"],
+            interview_current_field="age",
+            interview_last_question="나이가 어떻게 되세요?",
+            interview_last_answer="잘 모르겠어요",
+        )
+        await initial_interview_node(state)
+
+        mock_ask.assert_called_once_with(
+            field="age",
+            re_ask=True,
+            pre_assistant_message="나이가 어떻게 되세요?",
+            pre_user_message="잘 모르겠어요",
+        )
+
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
+    @patch("agents.initial_interview.interrupt", return_value="26살이요")
+    async def test_successful_reask_clears_tracking_fields(
+        self, mock_interrupt, mock_ask, mock_extract
+    ):
+        mock_ask.return_value = "나이를 숫자로 말씀해주세요."
+        mock_extract.return_value = {
+            "exist": True,
+            "value": 26,
+            "re_ask": False,
+            "reasoning": "",
+        }
+
+        state = _base_state(
+            initial_missing_fields=["age"],
+            interview_current_field="age",
+            interview_last_question="나이가 어떻게 되세요?",
+            interview_last_answer="잘 모르겠어요",
+        )
+        result = await initial_interview_node(state)
+
+        assert result["interview_current_field"] is None
+        assert result["interview_last_question"] == ""
+        assert result["interview_last_answer"] == ""
 
 
 class TestDisabilitySeverityHandling:
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
     @patch("agents.initial_interview.interrupt", return_value="장애가 있습니다")
-    @patch("agents.initial_interview.load_prompt", return_value="system prompt")
-    @patch("agents.initial_interview.get_llm")
     async def test_disability_true_adds_severity_to_missing(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
+        self, mock_interrupt, mock_ask, mock_extract
     ):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_ProfileExtraction(disability=True)
-        )
+        mock_ask.return_value = "장애가 있으신가요?"
+        mock_extract.return_value = {
+            "exist": True,
+            "value": True,
+            "re_ask": False,
+            "reasoning": "",
+        }
 
         state = _base_state(initial_missing_fields=["disability"])
         result = await initial_interview_node(state)
 
         assert "disability_severity" in result["initial_missing_fields"]
 
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
     @patch("agents.initial_interview.interrupt", return_value="장애 없습니다")
-    @patch("agents.initial_interview.load_prompt", return_value="system prompt")
-    @patch("agents.initial_interview.get_llm")
-    async def test_disability_false_no_severity_in_missing(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
+    async def test_disability_false_removes_severity_from_missing(
+        self, mock_interrupt, mock_ask, mock_extract
     ):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_ProfileExtraction(disability=False)
-        )
+        mock_ask.return_value = "장애가 있으신가요?"
+        mock_extract.return_value = {
+            "exist": True,
+            "value": False,
+            "re_ask": False,
+            "reasoning": "",
+        }
 
         state = _base_state(
             initial_missing_fields=["disability", "disability_severity"]
@@ -156,104 +270,71 @@ class TestDisabilitySeverityHandling:
 
         assert "disability_severity" not in result["initial_missing_fields"]
 
-    @patch("agents.initial_interview.interrupt", return_value="중증 장애입니다")
-    @patch("agents.initial_interview.load_prompt", return_value="system prompt")
-    @patch("agents.initial_interview.get_llm")
+    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
+    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
+    @patch("agents.initial_interview.interrupt", return_value="중증입니다")
     async def test_disability_severity_collected_removes_from_missing(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
+        self, mock_interrupt, mock_ask, mock_extract
     ):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_ProfileExtraction(
-                disability=True,
-                disability_severity=DisabilitySeverity.SEVERE,
-            )
-        )
+        mock_ask.return_value = "장애 정도가 어떻게 되세요?"
+        mock_extract.return_value = {
+            "exist": True,
+            "value": "중증",
+            "re_ask": False,
+            "reasoning": "",
+        }
 
-        state = _base_state(initial_missing_fields=["disability_severity"])
+        profile = UserProfile(disability=True)
+        state = _base_state(
+            user_profile=profile,
+            initial_missing_fields=["disability_severity"],
+        )
         result = await initial_interview_node(state)
 
         assert "disability_severity" not in result["initial_missing_fields"]
         assert result["user_profile"].disability_severity == DisabilitySeverity.SEVERE
 
 
-class TestStructuredOutputRetry:
-    async def test_all_fields_remain_on_max_retry_failure(self):
+class TestApplyValue:
+    def test_age_converts_to_int(self):
         profile = UserProfile()
-        missing = ["age", "region"]
+        result = _apply_value(profile, "age", "26")
+        assert result.age == 26
+        assert isinstance(result.age, int)
 
-        with patch("agents.initial_interview.get_llm") as mock_get_llm:
-            mock_llm = MagicMock()
-            mock_extractor = AsyncMock()
-            mock_extractor.ainvoke = AsyncMock(side_effect=Exception("파싱 실패"))
-            mock_llm.with_structured_output.return_value = mock_extractor
-            mock_get_llm.return_value = mock_llm
-
-            new_profile, new_missing = await _extract_profile(
-                profile, missing, "내 답변", []
-            )
-
-        assert new_profile == profile
-        assert new_missing == missing
-
-    async def test_retries_exactly_max_retry_plus_one_times(self):
+    def test_marital_status_converts_to_enum(self):
         profile = UserProfile()
+        result = _apply_value(profile, "marital_status", "미혼")
+        assert result.marital_status == MaritalStatus.SINGLE
 
-        with patch("agents.initial_interview.get_llm") as mock_get_llm:
-            mock_llm = MagicMock()
-            mock_extractor = AsyncMock()
-            mock_extractor.ainvoke = AsyncMock(side_effect=Exception("파싱 실패"))
-            mock_llm.with_structured_output.return_value = mock_extractor
-            mock_get_llm.return_value = mock_llm
-
-            await _extract_profile(profile, ["age"], "내 답변", [])
-
-            assert mock_extractor.ainvoke.call_count == 3  # 1 + _MAX_RETRY(2)
-
-    async def test_succeeds_on_second_attempt(self):
+    def test_disability_converts_to_bool(self):
         profile = UserProfile()
-        missing = ["age"]
-
-        with patch("agents.initial_interview.get_llm") as mock_get_llm:
-            mock_llm = MagicMock()
-            mock_extractor = AsyncMock()
-            mock_extractor.ainvoke = AsyncMock(
-                side_effect=[Exception("1차 실패"), _ProfileExtraction(age=55)]
-            )
-            mock_llm.with_structured_output.return_value = mock_extractor
-            mock_get_llm.return_value = mock_llm
-
-            new_profile, new_missing = await _extract_profile(
-                profile, missing, "55살", []
-            )
-
-        assert new_profile.age == 55
-        assert "age" not in new_missing
+        result = _apply_value(profile, "disability", True)
+        assert result.disability is True
 
 
-class TestGenerateQuestion:
-    @patch("agents.initial_interview.load_prompt", return_value="system prompt")
-    @patch("agents.initial_interview.get_llm")
-    async def test_returns_llm_content(self, mock_get_llm, mock_load_prompt, mock_llm):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.ainvoke = AsyncMock(
-            return_value=MagicMock(content="나이가 어떻게 되세요?")
+class TestUpdateMissing:
+    def test_removes_collected_field(self):
+        profile = UserProfile()
+        result = _update_missing("age", profile, ["age", "region"])
+        assert "age" not in result
+        assert "region" in result
+
+    def test_disability_false_removes_severity(self):
+        profile = UserProfile(disability=False)
+        result = _update_missing(
+            "disability", profile, ["disability", "disability_severity"]
         )
+        assert "disability_severity" not in result
 
-        question = await _generate_question(UserProfile(), ["age"], [])
+    def test_disability_true_adds_severity_if_absent(self):
+        profile = UserProfile(disability=True)
+        result = _update_missing("disability", profile, ["disability"])
+        assert "disability_severity" in result
 
-        assert question == "나이가 어떻게 되세요?"
-
-    @patch("agents.initial_interview.load_prompt", return_value="system prompt")
-    @patch("agents.initial_interview.get_llm")
-    async def test_history_included_in_messages(
-        self, mock_get_llm, mock_load_prompt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="질문"))
-
-        history = [HumanMessage(content="안녕하세요"), AIMessage(content="안녕하세요!")]
-        await _generate_question(UserProfile(), ["age"], history)
-
-        call_messages = mock_llm.ainvoke.call_args[0][0]
-        assert any(m.content == "안녕하세요" for m in call_messages)
+    def test_disability_true_no_duplicate_severity(self):
+        profile = UserProfile(disability=True)
+        result = _update_missing(
+            "disability", profile, ["disability", "disability_severity"]
+        )
+        assert result.count("disability_severity") == 1

--- a/tests/test_initial_interview_integration.py
+++ b/tests/test_initial_interview_integration.py
@@ -1,10 +1,10 @@
-"""실제 LLM을 호출하는 통합 테스트. 실행: uv run pytest -s -m integration."""
+"""실제 hwnv.cloud API를 호출하는 통합 테스트. 실행: uv run pytest -s -m integration."""
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage
 
-from agents.initial_interview import _extract_profile, _generate_question
+from agents.initial_interview import _apply_value, _update_missing
 from graph.state import UserProfile
+from tools import hwnv_client
 
 # 라운드별 사용자 답변 시나리오 (순서대로 소진)
 _USER_ANSWERS = [
@@ -30,7 +30,6 @@ class TestFullInterviewFlow:
             "employment_status",
             "income_level",
         ]
-        history = []
         answers = list(_USER_ANSWERS)
         round_num = 0
 
@@ -40,9 +39,10 @@ class TestFullInterviewFlow:
 
         while missing:
             round_num += 1
-            print(f"\n[라운드 {round_num}] 남은 필드: {missing}")
+            field = missing[0]
+            print(f"\n[라운드 {round_num}] 남은 필드: {missing}, 현재 필드: {field}")
 
-            question = await _generate_question(profile, missing, history)
+            question = await hwnv_client.ask_question(field=field, re_ask=False)
             print(f"AI  : {question}")
 
             if not answers:
@@ -52,13 +52,12 @@ class TestFullInterviewFlow:
             user_answer = answers.pop(0)
             print(f"사용자: {user_answer}")
 
-            ai_msg = AIMessage(content=question)
-            human_msg = HumanMessage(content=user_answer)
+            result = await hwnv_client.extract_value(field, question, user_answer)
+            print(f"추출 결과: {result}")
 
-            profile, missing = await _extract_profile(
-                profile, missing, user_answer, history + [ai_msg]
-            )
-            history.extend([ai_msg, human_msg])
+            if result.get("exist"):
+                profile = _apply_value(profile, field, result["value"])
+                missing = _update_missing(field, profile, missing)
 
         print("\n" + "=" * 60)
         print(f"최종 프로필: {profile.model_dump(exclude_none=True)}")

--- a/tools/hwnv_client.py
+++ b/tools/hwnv_client.py
@@ -1,0 +1,90 @@
+"""hwnv.cloud 인터뷰 API 클라이언트."""
+
+import json
+
+import httpx
+
+_BASE_URL = "https://hwnv.cloud"
+_TIMEOUT = 120.0
+
+
+async def ask_question(
+    field: str,
+    re_ask: bool,
+    pre_assistant_message: str = "",
+    pre_user_message: str = "",
+) -> str:
+    """Asker 모델로 특정 필드에 대한 질문을 생성합니다.
+
+    Args:
+        field: 수집할 항목 (age, region 등)
+        re_ask: 재질문 여부
+        pre_assistant_message: 직전 봇 발화 (재질문 시 자연스러운 연결용)
+        pre_user_message: 직전 사용자 발화
+
+    Returns:
+        생성된 질문 문자열
+    """
+    payload: dict = {"information": field, "re_ask": re_ask}
+    if pre_assistant_message:
+        payload["pre_assistant_message"] = pre_assistant_message
+        payload["pre_user_message"] = pre_user_message
+
+    async with httpx.AsyncClient(base_url=_BASE_URL, timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "asker",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": json.dumps(payload, ensure_ascii=False),
+                    }
+                ],
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"]
+
+
+async def extract_value(
+    field: str,
+    assistant_message: str,
+    user_message: str,
+) -> dict:
+    """Interviewer 모델로 사용자 답변에서 값을 추출합니다.
+
+    Args:
+        field: 추출할 항목
+        assistant_message: 봇이 했던 질문
+        user_message: 사용자 답변
+
+    Returns:
+        {"exist": bool, "value": any | None, "re_ask": bool, "reasoning": str}
+    """
+    payload = {
+        "information": field,
+        "assistant_message": assistant_message,
+        "user_message": user_message,
+    }
+
+    async with httpx.AsyncClient(base_url=_BASE_URL, timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "interviewer",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": json.dumps(payload, ensure_ascii=False),
+                    }
+                ],
+            },
+        )
+        resp.raise_for_status()
+        content = resp.json()["choices"][0]["message"]["content"]
+        if content.startswith("```"):
+            content = content.split("```", 2)[1]
+            if content.startswith("json"):
+                content = content[4:]
+        return json.loads(content.strip())


### PR DESCRIPTION
 ## 📝 PR 설명

  - 1단계 인터뷰 노드의 질문 생성·값 추출을 in-house LLM에서 **hwnv.cloud API**로 교체합니다.
  - 추출 실패 시 직전 대화 컨텍스트를 유지하며 동일 필드를 재질문하는 re-ask 흐름을 추가합니다.

  ## 🛠️ 작업 상세 내용

  - `tools/hwnv_client.py` 신규 작성: `ask_question`(asker 모델), `extract_value`(interviewer 모델) 구현. 타임아웃 120s,
   markdown 감싸진 JSON 응답 파싱 처리 포함
  - `agents/initial_interview.py` 리팩토링: `_generate_question` / `_extract_profile` / `_ProfileExtraction` 제거,
  `_apply_value` / `_update_missing` 헬퍼로 교체
  - `graph/state.py`: `AgentState`에 re-ask 추적 필드 3개 추가 (`interview_current_field`, `interview_last_question`,
  `interview_last_answer`)
  - `main.py`: 신규 상태 필드 초기화
  - `tests/test_initial_interview.py`: 새 인터페이스 기준으로 테스트 전면 교체, re-ask 흐름 시나리오 및 `TestApplyValue`
   / `TestUpdateMissing` 유닛 테스트 추가

  ## 🧪 테스트 여부 및 확인 내용

  - `uv run pytest tests/test_initial_interview.py` 전체 통과
  - `test_live.py`로 hwnv.cloud API 실동작 확인 (ask_question / extract_value 왕복 테스트)

  ## 📸 스크린샷 (선택)

  ## 💬 기타 / 참고사항

  - hwnv.cloud API는 OpenAI 호환 포맷(`POST /v1/chat/completions`) 사용
  - `tools/rag_client.py` 원칙과 동일하게, hwnv.cloud 호출은 반드시 `tools/hwnv_client.py`를 통해서만 수행
  - `tools/llm.py`, `tools/prompt_loader.py` 의존성은 `initial_interview` 한정으로 제거됨 (다른 노드는 유지)

  ## 🔗 연관 이슈

  - Closes #30 
  - 해당 PR이 머지되면 이슈가 자동으로 닫힙니다.