### PR TITLE
feat: Phase 5 최종 통합 및 품질 개선 (5-0, 5-1, 5-2, 5-6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ GROQ_MODEL=llama-3.3-70b-versatile
 GRAPH_CHECKPOINTER=memory
 SQLITE_DB_PATH=./checkpoints.db
 
+# LLM 응답 파싱 실패 시 최대 재시도 횟수 (기본값 2 → 총 3회 시도)
+LLM_MAX_RETRY=2
+
+# detail_interview에서 LLM에 넘길 최근 대화 히스토리 최대 개수 (기본값 10개 메시지)
+HISTORY_WINDOW_SIZE=10
+
 # RAG 서비스 연동 — RAG 팀에서 제공한 서버 주소로 변경
 # 단위 테스트(test_rag_client_stub.py 등)는 httpx mock을 사용하므로 이 값 불필요
 # 통합 테스트(test_rag_integration.py)는 실제 RAG 서버가 실행 중이어야 함

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ LLM_MAX_RETRY=2
 # detail_interview에서 LLM에 넘길 최근 대화 히스토리 최대 개수 (기본값 10개 메시지)
 HISTORY_WINDOW_SIZE=10
 
+# CORS 허용 출처 — 쉼표로 여러 origin 구분 가능 (배포 시 실제 프론트엔드 URL로 변경)
+CORS_ALLOW_ORIGINS=http://localhost:3000
+
 # RAG 서비스 연동 — RAG 팀에서 제공한 서버 주소로 변경
 # 단위 테스트(test_rag_client_stub.py 등)는 httpx mock을 사용하므로 이 값 불필요
 # 통합 테스트(test_rag_integration.py)는 실제 RAG 서버가 실행 중이어야 함

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 .venv/
 __pycache__/
 *.pyc
-.pytest_cache/
+.pytest_cache/*.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,11 @@ GROQ_API_KEY=
 GROQ_MODEL=llama-3.3-70b-versatile
 GRAPH_CHECKPOINTER=memory
 SQLITE_DB_PATH=./checkpoints.db
+LLM_MAX_RETRY=2
+HISTORY_WINDOW_SIZE=10
 RAG_SERVICE_URL=http://localhost:8000
 RAG_SEARCH_TOP_K=5
+CORS_ALLOW_ORIGINS=http://localhost:3000
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -1,1 +1,150 @@
-# ai
+# 복지드림 AI 에이전트
+
+사용자가 기본 정보를 입력하면 AI가 지원 가능한 복지 서비스를 검색·추천하고, 선택된 서비스의 신청서 작성 가이드와 최종 보고서를 생성하는 LangGraph 기반 챗봇 서버입니다.
+
+## 아키텍처
+
+```
+START
+  └─▶ initial_interview ◀─┐  (1단계: 나이·소득·장애 여부 등 최소 정보 수집)
+            │ 완료          └─ 정보 부족 시 재진입
+            ▼
+       rag_search             (수집된 정보로 복지 서비스 후보 검색)
+            │ 후보 없음 ──▶ END
+            ▼
+      service_select          (사용자가 후보 목록 중 서비스 선택 — HitL)
+            │
+            ▼
+       rag_detail             (선택된 서비스 상세 정보 조회)
+            │
+            ▼
+     detail_interview ◀─┐   (2단계: 선택 서비스 특화 추가 정보 수집)
+            │ 완료        └─ 정보 부족 시 재진입
+            ▼
+   document_guidance          (필요 서류 안내)
+            │
+            ▼
+      draft_writer            (신청서 항목별 작성 가이드 생성)
+            │
+            ▼
+     report_writer            (최종 보고서 생성)
+            │
+           END
+```
+
+**1단계 인터뷰** — hwnv.cloud API (asker/interviewer 모델) 사용  
+**2단계 이후** — Groq LLM (llama-3.3-70b-versatile) 사용
+
+## 환경 설정
+
+```bash
+cp .env.example .env
+```
+
+`.env` 파일에서 아래 값을 설정합니다.
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `GROQ_API_KEY` | — | Groq API 키 (필수) |
+| `GROQ_MODEL` | `llama-3.3-70b-versatile` | 사용할 Groq 모델 |
+| `GRAPH_CHECKPOINTER` | `memory` | `memory` (개발) / `sqlite` (운영) |
+| `SQLITE_DB_PATH` | `./checkpoints.db` | SQLite 저장 경로 (sqlite 모드일 때) |
+| `RAG_SERVICE_URL` | `http://localhost:8000` | RAG 서버 주소 |
+| `RAG_SEARCH_TOP_K` | `5` | RAG 검색 후보 최대 수 |
+| `LLM_MAX_RETRY` | `2` | LLM 파싱 실패 시 최대 재시도 횟수 |
+| `HISTORY_WINDOW_SIZE` | `10` | LLM에 넘길 최근 대화 메시지 최대 개수 |
+
+## 실행
+
+```bash
+# 의존성 설치
+uv sync --all-groups
+
+# 서버 실행 (기본 포트 8001 — RAG 서버가 8000 사용 중)
+uv run uvicorn server:app --reload --port 8001
+```
+
+> RAG 서버가 별도로 실행 중이어야 합니다. `RAG_SERVICE_URL`을 RAG 서버 주소로 설정하세요.
+
+## API
+
+### `POST /chat/start`
+
+새 대화 세션을 시작합니다. 서버가 첫 번째 인터뷰 질문을 반환합니다.
+
+**요청:** 바디 없음
+
+**응답 예시:**
+```json
+{
+  "thread_id": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "interview",
+  "data": {
+    "question": "나이가 어떻게 되세요?",
+    "missing_fields": ["age", "region", "household_size", "..."]
+  }
+}
+```
+
+---
+
+### `POST /chat/message`
+
+사용자 메시지를 전송하고 다음 응답을 받습니다.
+
+**요청 바디:**
+```json
+{
+  "thread_id": "550e8400-e29b-41d4-a716-446655440000",
+  "message": "35살이에요"
+}
+```
+
+**응답 `type` 종류:**
+
+| type | 설명 | data 주요 필드 |
+|------|------|----------------|
+| `interview` | 인터뷰 진행 중, 다음 질문 | `question`, `missing_fields` |
+| `service_select` | 복지 서비스 선택 요청 | `candidates` (목록 텍스트), `welfare_candidates` (전체 데이터) |
+| `done` | 모든 단계 완료 | `final_report`, `document_guidance`, `application_guide`, `selected_service` |
+| `no_results` | 해당하는 복지 서비스 없음 | — |
+
+**`service_select` 응답 시** — `message`에 후보 번호(예: `"1"`)를 전송하면 됩니다.
+
+---
+
+### 전체 흐름 예시
+
+```
+POST /chat/start
+  → type: "interview", question: "나이가 어떻게 되세요?"
+
+POST /chat/message  { message: "35살이에요" }
+  → type: "interview", question: "어느 지역에 사세요?"
+
+... (인터뷰 반복) ...
+
+POST /chat/message  { message: "기초생활수급자예요" }
+  → type: "service_select", candidates: "1. 기초연금\n2. 장애인활동지원\n..."
+
+POST /chat/message  { message: "1" }
+  → type: "interview", question: "장애 유형이 어떻게 되세요?"
+
+... (2단계 인터뷰 반복) ...
+
+POST /chat/message  { message: "지체장애입니다" }
+  → type: "done", final_report: "..."
+```
+
+## 테스트
+
+```bash
+# 단위 테스트 전체 실행
+uv run pytest tests/ -v
+
+# 통합 테스트 (RAG 서버 실행 필요)
+uv run pytest tests/test_rag_integration.py -v
+
+# hwnv.cloud 연동 테스트 (API 접근 필요)
+uv run pytest tests/test_initial_interview_integration.py -v
+```

--- a/agents/detail_interview.py
+++ b/agents/detail_interview.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
@@ -25,7 +26,9 @@ _FIELD_LABELS: dict[str, str] = {
     "is_single_parent": "한부모 가정 여부",
 }
 
-_MAX_RETRY = 2
+_MAX_RETRY = int(os.getenv("LLM_MAX_RETRY", "2"))
+_HISTORY_WINDOW = int(os.getenv("HISTORY_WINDOW_SIZE", "10"))
+_RETRY_MSG = "이해하지 못했습니다. 좀 더 구체적으로 말씀해주시겠어요?"
 
 
 class _DetailExtraction(BaseModel):
@@ -79,10 +82,12 @@ async def _extract_profile(
     missing: list[str],
     user_answer: str,
     history: list,
-) -> tuple[UserProfile, list[str]]:
-    """사용자 답변에서 2단계 프로필 필드를 추출합니다. 실패 시 최대 2회 재시도.
+) -> tuple[UserProfile, list[str], bool]:
+    """사용자 답변에서 2단계 프로필 필드를 추출합니다.
 
-    파싱 실패가 모든 재시도에서 발생하면 기존 profile과 missing을 그대로 반환합니다.
+    실패 시 최대 LLM_MAX_RETRY회 재시도.
+    반환값: (profile, missing, extraction_failed)
+    - extraction_failed=True: 모든 재시도 소진, 기존 profile/missing 유지
     "extra:KEY" 접두사 필드는 user_profile.extra_fields에 저장합니다.
     """
     regular_missing = [f for f in missing if not f.startswith("extra:")]
@@ -110,7 +115,7 @@ async def _extract_profile(
             continue
 
     if extraction is None:
-        return profile, missing
+        return profile, missing, True
 
     # 일반 필드 업데이트
     regular_updates = {
@@ -134,7 +139,7 @@ async def _extract_profile(
         if key not in new_profile.extra_fields:
             new_missing.append(f"extra:{key}")
 
-    return new_profile, new_missing
+    return new_profile, new_missing, False
 
 
 async def detail_interview_node(state: AgentState) -> dict:
@@ -146,22 +151,26 @@ async def detail_interview_node(state: AgentState) -> dict:
     if not missing:
         return {}
 
-    question = await _generate_question(
-        profile, missing, selected, list(state["messages"])
-    )
+    history = list(state["messages"])[-_HISTORY_WINDOW:]
+
+    question = await _generate_question(profile, missing, selected, history)
     ai_message = AIMessage(content=question)
 
     user_answer: str = interrupt({"question": question, "missing_fields": missing})
 
-    new_profile, new_missing = await _extract_profile(
+    new_profile, new_missing, extraction_failed = await _extract_profile(
         profile,
         missing,
         user_answer,
-        list(state["messages"]) + [ai_message],
+        (history + [ai_message])[-_HISTORY_WINDOW:],
     )
 
+    messages = [ai_message, HumanMessage(content=user_answer)]
+    if extraction_failed:
+        messages.append(AIMessage(content=_RETRY_MSG))
+
     return {
-        "messages": [ai_message, HumanMessage(content=user_answer)],
+        "messages": messages,
         "user_profile": new_profile,
         "detail_missing_fields": new_missing,
     }

--- a/docs/phase4.md
+++ b/docs/phase4.md
@@ -20,3 +20,25 @@
 
 - `GROQ_API_KEY` 없이 로컬에서 전체 파이프라인 동작
 - 기존 테스트 코드 수정 없이 CI 통과
+
+---
+
+## hwnv.cloud API 제약 사항 (전환 전 사전 확인 필요)
+
+hwnv.cloud API는 **바로 이전 대화 1개만 수신**한다. 전체 대화 히스토리 배열을 전달해도 마지막 메시지만 처리됨.
+
+### B 담당 수정 필요 파일
+
+| 파일 | 현재 구현 | 필요 변경 |
+|------|-----------|-----------|
+| `agents/detail_interview.py` | `HISTORY_WINDOW_SIZE`로 최대 10개 messages 배열 전달 | 히스토리 전달 로직 제거, `_HISTORY_WINDOW` 변수 및 슬라이딩 윈도우 삭제 |
+
+### B 담당 수정 불필요 파일
+
+| 파일 | 이유 |
+|------|------|
+| `agents/draft_writer.py` | 단일 프롬프트 문자열만 전달 — 이미 호환 |
+
+### A 담당 확인 필요 파일
+
+`document_guidance.py`, `report_writer.py` 등 히스토리를 messages 배열로 전달하는 노드가 있으면 동일하게 수정 필요. A 담당이므로 A와 협의.

--- a/graph/builder.py
+++ b/graph/builder.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import AsyncExitStack
 
 from dotenv import load_dotenv
 from langgraph.checkpoint.memory import MemorySaver
@@ -16,6 +17,9 @@ from agents.service_select import service_select_node
 from graph.state import AgentState
 
 load_dotenv()
+
+# SQLite 모드일 때 커넥션 수명을 앱과 동일하게 유지하기 위한 스택
+_checkpointer_stack: AsyncExitStack | None = None
 
 
 # ── 조건부 엣지 함수 ──
@@ -42,30 +46,17 @@ def route_after_detail_interview(state: AgentState) -> str:
     return "document_guidance"
 
 
-# ── Checkpointer 팩토리 ──
-
-
-def _build_checkpointer():
-    """환경변수 GRAPH_CHECKPOINTER에 따라 checkpointer를 반환합니다."""
-    mode = os.getenv("GRAPH_CHECKPOINTER", "memory")
-
-    if mode == "sqlite":
-        from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
-
-        db_path = os.getenv("SQLITE_DB_PATH", "./checkpoints.db")
-        return AsyncSqliteSaver.from_conn_string(db_path)
-
-    if mode == "postgres":
-        raise NotImplementedError("Postgres checkpointer is not configured yet.")
-
-    return MemorySaver()
-
-
 # ── 그래프 빌더 ──
 
 
-def build_graph():
-    """StateGraph를 조립하여 컴파일된 그래프를 반환합니다."""
+async def build_graph():
+    """StateGraph를 조립하여 컴파일된 그래프를 반환합니다.
+
+    SQLite 모드: AsyncSqliteSaver를 AsyncExitStack으로 열어 앱 수명 동안 유지.
+    Memory 모드: MemorySaver를 사용 (동기, 기본값).
+    """
+    global _checkpointer_stack
+
     builder = StateGraph(AgentState)
 
     # 노드 등록
@@ -89,8 +80,21 @@ def build_graph():
     builder.add_edge("draft_writer", "report_writer")
     builder.add_edge("report_writer", END)
 
-    checkpointer = _build_checkpointer()
-    return builder.compile(checkpointer=checkpointer)
+    mode = os.getenv("GRAPH_CHECKPOINTER", "memory")
 
+    if mode == "sqlite":
+        from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
-graph = build_graph()
+        db_path = os.getenv("SQLITE_DB_PATH", "./checkpoints.db")
+        _checkpointer_stack = AsyncExitStack()
+        # enter_async_context: context manager를 "열어둔 채로" 스택에 등록
+        # 스택이 살아있는 한 DB 커넥션이 유지됨
+        checkpointer = await _checkpointer_stack.enter_async_context(
+            AsyncSqliteSaver.from_conn_string(db_path)
+        )
+        return builder.compile(checkpointer=checkpointer)
+
+    if mode == "postgres":
+        raise NotImplementedError("Postgres checkpointer is not configured yet.")
+
+    return builder.compile(checkpointer=MemorySaver())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "httpx>=0.28.1",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
+    "langgraph-checkpoint-sqlite>=3.0.3",
 ]
 
 [tool.ruff]

--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
@@ -10,12 +11,25 @@ from fastapi.middleware.cors import CORSMiddleware
 from langgraph.types import Command
 from pydantic import BaseModel
 
-from graph.builder import graph  # builder.py 내부에서 load_dotenv() 호출
+from graph.builder import build_graph
 from graph.state import UserProfile, WelfareCandidate
 
 load_dotenv()
 
-app = FastAPI(title="BokjiDream AI Server")
+# 서버 시작 시 lifespan에서 초기화됨
+graph = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """서버 시작 시 그래프를 초기화하고, 종료 시 리소스를 정리합니다."""
+    global graph
+    graph = await build_graph()
+    yield
+    # SQLite 모드일 경우 _checkpointer_stack이 GC될 때 커넥션 자동 종료
+
+
+app = FastAPI(title="BokjiDream AI Server", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,

--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import uuid
 from contextlib import asynccontextmanager
 
@@ -31,9 +32,11 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="BokjiDream AI Server", lifespan=lifespan)
 
+_CORS_ORIGINS = os.getenv("CORS_ALLOW_ORIGINS", "http://localhost:3000").split(",")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=_CORS_ORIGINS,
     allow_methods=["POST"],
     allow_headers=["Content-Type"],
 )

--- a/tests/test_detail_interview.py
+++ b/tests/test_detail_interview.py
@@ -191,7 +191,7 @@ class TestExtraFieldsHandling:
             )
             mock_get_llm.return_value = mock_llm
 
-            new_profile, _ = await _extract_profile(profile, missing, "새값", [])
+            new_profile, _, _ = await _extract_profile(profile, missing, "새값", [])
 
         assert new_profile.extra_fields["기존키"] == "기존값"
         assert new_profile.extra_fields["새키"] == "새값"
@@ -209,12 +209,13 @@ class TestStructuredOutputRetry:
             mock_llm.with_structured_output.return_value = mock_extractor
             mock_get_llm.return_value = mock_llm
 
-            new_profile, new_missing = await _extract_profile(
+            new_profile, new_missing, failed = await _extract_profile(
                 profile, missing, "내 답변", []
             )
 
         assert new_profile == profile
         assert new_missing == missing
+        assert failed is True
 
     async def test_retries_exactly_max_retry_plus_one_times(self):
         profile = UserProfile()
@@ -246,12 +247,13 @@ class TestStructuredOutputRetry:
             mock_llm.with_structured_output.return_value = mock_extractor
             mock_get_llm.return_value = mock_llm
 
-            new_profile, new_missing = await _extract_profile(
+            new_profile, new_missing, failed = await _extract_profile(
                 profile, missing, "전세입니다", []
             )
 
         assert new_profile.housing_type == "전세"
         assert "housing_type" not in new_missing
+        assert failed is False
 
 
 class TestGenerateQuestion:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -35,12 +35,12 @@ def _base_state(**overrides) -> dict:
 
 
 class TestGraphCompile:
-    def test_graph_compiles(self):
-        g = build_graph()
+    async def test_graph_compiles(self):
+        g = await build_graph()
         assert g is not None
 
-    def test_all_nodes_registered(self):
-        g = build_graph()
+    async def test_all_nodes_registered(self):
+        g = await build_graph()
         nodes = list(g.get_graph().nodes.keys())
         expected = [
             "initial_interview",

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -779,6 +788,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/44/a8df45d1e8b4637e29789fa8bae1db022c953cc7ac80093cfc52e923547e/langgraph_checkpoint-4.0.1.tar.gz", hash = "sha256:b433123735df11ade28829e40ce25b9be614930cd50245ff2af60629234befd9", size = 158135, upload-time = "2026-02-27T21:06:16.092Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/4c/09a4a0c42f5d2fc38d6c4d67884788eff7fd2cfdf367fdf7033de908b4c0/langgraph_checkpoint-4.0.1-py3-none-any.whl", hash = "sha256:e3adcd7a0e0166f3b48b8cf508ce0ea366e7420b5a73aa81289888727769b034", size = 50453, upload-time = "2026-02-27T21:06:14.293Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint-sqlite"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "langgraph-checkpoint" },
+    { name = "sqlite-vec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/61/40b7f8f29d6de92406e668c35265f409f57064907e31eae84ab3f2a3e3e1/langgraph_checkpoint_sqlite-3.0.3.tar.gz", hash = "sha256:438c234d37dabda979218954c9c6eb1db73bee6492c2f1d3a00552fe23fa34ed", size = 123876, upload-time = "2026-01-19T00:38:44.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/d8/84ef22ee1cc485c4910df450108fd5e246497379522b3c6cfba896f71bf6/langgraph_checkpoint_sqlite-3.0.3-py3-none-any.whl", hash = "sha256:02eb683a79aa6fcda7cd4de43861062a5d160dbbb990ef8a9fd76c979998a952", size = 33593, upload-time = "2026-01-19T00:38:43.288Z" },
 ]
 
 [[package]]
@@ -1685,6 +1708,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2011,6 +2046,7 @@ dependencies = [
     { name = "langchain-community" },
     { name = "langchain-groq" },
     { name = "langgraph" },
+    { name = "langgraph-checkpoint-sqlite" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "uvicorn", extra = ["standard"] },
@@ -2034,6 +2070,7 @@ requires-dist = [
     { name = "langchain-community", specifier = ">=0.3.0" },
     { name = "langchain-groq", specifier = ">=1.1.2" },
     { name = "langgraph", specifier = ">=0.4.0" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.3" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },


### PR DESCRIPTION
## 📝 PR 설명

- Phase 5 작업 중 B 담당 항목(5-0, 5-1, 5-2, 5-6) 구현
- CORS 허용 출처 환경변수화 포함 (이슈 #36)

## 🛠️ 작업 상세 내용

- **5-0** `AsyncSqliteSaver` 비동기 컨텍스트 매니저 적용 및 FastAPI lifespan으로 그래프 초기화 타이밍 수정
  - `build_graph()`를 `async def`로 전환, `AsyncExitStack`으로 SQLite 연결 수명 관리
  - `server.py`에 `lifespan` 핸들러 추가 — 앱 시작 시 그래프 한 번만 초기화
  - `langgraph-checkpoint-sqlite` 패키지 추가
- **5-1** LLM structured output 파싱 실패 시 사용자 안내 메시지 추가
  - `_extract_profile()` 반환값을 `(profile, missing, extraction_failed)` 3-tuple로 변경
  - 재시도 소진 시 "이해하지 못했습니다" 메시지를 대화에 추가하여 무한 루프 방지
- **5-2** 대화 히스토리 슬라이딩 윈도우 적용
  - `HISTORY_WINDOW_SIZE` 환경변수로 LLM에 전달할 최근 메시지 개수 제한 (기본 10개)
  - `LLM_MAX_RETRY` 환경변수로 재시도 횟수 설정 가능
- **5-6** README 전면 재작성
  - 아키텍처 다이어그램, 환경변수 표, API 명세(`/chat/start`, `/chat/message`) 추가
  - 응답 타입 목록 및 전체 대화 흐름 예시 포함
- **#36** CORS 허용 출처(`allow_origins`)를 `CORS_ALLOW_ORIGINS` 환경변수로 분리
  - 배포 시 코드 수정 없이 프론트엔드 URL 설정 가능
  - 쉼표 구분으로 여러 origin 허용 가능
- **추가** `checkpoints.db` `.gitignore` 추가, Phase 4 hwnv.cloud 전환 시 수정 필요 사항 문서화

## 🧪 테스트 여부 및 확인 내용

- 단위 테스트 117개 전체 통과
- RAG 통합 테스트: RAG 서버 미실행 상태로 연결 실패 (코드 문제 아님)
- hwnv.cloud 통합 테스트: 외부 서버 일시 502 오류 (코드 문제 아님)

## 📸 스크린샷 (선택)

## 💬 기타 / 참고사항

- 5-5(E2E 테스트) 및 5-7(main 머지·태그)는 전체 Phase 5 완료 후 별도 처리 예정
- hwnv.cloud가 이전 대화 1개만 수신하는 제약으로 인해 Phase 4 전환 시 `detail_interview.py` 슬라이딩 윈도우 제거 필요 — `docs/phase4.md`에 기록

## 🔗 연관 이슈

- Closes #34
- Closes #36
- 해당 PR이 머지되면 이슈가 자동으로 닫힙니다.