### PR TITLE
[AI] rag_detail_node detail_missing_fields LLM 추론 로직 구현

### DIFF
--- a/agents/rag_detail.py
+++ b/agents/rag_detail.py
@@ -1,14 +1,92 @@
 """RAG 상세 조회 노드 — 선택된 서비스의 required_documents 등 상세 필드 보완."""
 
-from langchain_core.messages import AIMessage
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from pydantic import BaseModel
 
 import tools.rag_client as rag_client
-from graph.state import AgentState, WelfareCandidate
+from tools.llm import get_llm
+
+if TYPE_CHECKING:
+    from graph.state import AgentState, UserProfile, WelfareCandidate
+
+_MAX_RETRY = int(os.getenv("LLM_MAX_RETRY", "2"))
+
+_STAGE_2_FIELDS = [
+    "disability_type",
+    "disability_grade",
+    "children_ages",
+    "housing_type",
+    "household_type",
+    "is_veteran",
+    "is_single_parent",
+]
+
+
+class _RequiredFields(BaseModel):
+    regular_fields: list[str] = []
+    extra_fields: list[str] = []
+
+
+async def _infer_missing_fields(
+    profile: UserProfile,
+    tgtr_dtl_cn: str,
+    slct_crit_cn: str,
+    trgter_indvdl: list[str],
+) -> list[str]:
+    """자격 요건 텍스트에서 추가 수집이 필요한 UserProfile 필드를 추론합니다."""
+    system = (
+        "당신은 복지 서비스 자격 심사 전문가입니다.\n"
+        "주어진 서비스 자격 요건을 분석하여,"
+        " 사용자의 자격 여부 확인에 필요한 추가 정보를 결정하세요.\n\n"
+        f"수집 가능한 표준 필드 목록: {', '.join(_STAGE_2_FIELDS)}\n"
+        "규칙:\n"
+        "- 서비스 자격 요건에 필요한 표준 필드"
+        " → regular_fields에 필드명 추가\n"
+        "- 표준 필드에 없는 특수 정보가 필요한 경우"
+        " → extra_fields에 영문 snake_case 키 추가\n"
+        "- 현재 사용자 프로필에 이미 있는 정보는 포함하지 마세요\n\n"
+        f"현재 사용자 프로필: {profile.model_dump(exclude_none=True)}"
+    )
+    human = (
+        f"[대상자 상세]\n{tgtr_dtl_cn}\n\n"
+        f"[선정 기준]\n{slct_crit_cn}\n\n"
+        f"[대상자 유형]\n{', '.join(trgter_indvdl)}"
+    )
+
+    extractor = get_llm().with_structured_output(_RequiredFields)
+    result: _RequiredFields | None = None
+    for _ in range(_MAX_RETRY + 1):
+        try:
+            result = await extractor.ainvoke(
+                [SystemMessage(content=system), HumanMessage(content=human)]
+            )
+            break
+        except Exception:
+            continue
+
+    if result is None:
+        return []
+
+    missing: list[str] = []
+    for field in result.regular_fields:
+        if field in _STAGE_2_FIELDS and getattr(profile, field, None) is None:
+            missing.append(field)
+    for key in result.extra_fields:
+        if key not in profile.extra_fields:
+            missing.append(f"extra:{key}")
+
+    return missing
 
 
 async def rag_detail_node(state: AgentState) -> dict:
-    """선택된 서비스의 상세 정보를 조회하여 WelfareCandidate를 갱신."""
+    """RAG 상세 조회 후 selected_service와 detail_missing_fields를 갱신합니다."""
     selected: WelfareCandidate = state["selected_service"]
+    profile: UserProfile = state["user_profile"]
 
     detail = None
     for _ in range(2):
@@ -24,6 +102,7 @@ async def rag_detail_node(state: AgentState) -> dict:
         )
         return {
             "selected_service": selected,
+            "detail_missing_fields": [],
             "messages": [AIMessage(content=error_msg)],
         }
 
@@ -36,4 +115,14 @@ async def rag_detail_node(state: AgentState) -> dict:
         }
     )
 
-    return {"selected_service": updated}
+    missing_fields = await _infer_missing_fields(
+        profile=profile,
+        tgtr_dtl_cn=detail.get("tgtr_dtl_cn", ""),
+        slct_crit_cn=detail.get("slct_crit_cn", ""),
+        trgter_indvdl=detail.get("trgter_indvdl", []),
+    )
+
+    return {
+        "selected_service": updated,
+        "detail_missing_fields": missing_fields,
+    }

--- a/tests/test_rag_detail.py
+++ b/tests/test_rag_detail.py
@@ -1,10 +1,11 @@
 """RAG 상세 조회 노드 테스트."""
 
+import os
 from unittest.mock import AsyncMock, patch
 
 from langchain_core.messages import AIMessage
 
-from agents.rag_detail import rag_detail_node
+from agents.rag_detail import _infer_missing_fields, _RequiredFields, rag_detail_node
 from graph.state import (
     AgentState,
     EmploymentStatus,
@@ -42,6 +43,9 @@ def _make_state(**kwargs) -> AgentState:
         "document_guidance": "",
         "application_guide": "",
         "final_report": "",
+        "interview_current_field": None,
+        "interview_last_question": "",
+        "interview_last_answer": "",
     }
     defaults.update(kwargs)
     return defaults  # type: ignore[return-value]
@@ -177,14 +181,47 @@ class TestRagDetailNode:
         assert call_kwargs["slct_crit_cn"] == _DUMMY_DETAIL["slct_crit_cn"]
         assert call_kwargs["trgter_indvdl"] == _DUMMY_DETAIL["trgter_indvdl"]
 
+    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_first_attempt_fails_second_succeeds(
+        self, mock_get_detail, mock_infer
+    ):
+        """RAG 첫 시도 실패 → 두 번째 성공 → 정상 처리."""
+        mock_get_detail.side_effect = [Exception("일시 오류"), _DUMMY_DETAIL]
+        mock_infer.return_value = []
+
+        result = await rag_detail_node(_make_state())
+
+        assert mock_get_detail.call_count == 2
+        assert result["selected_service"].detail_fetched is True
+        assert result["selected_service"].required_documents == [
+            "사회보장급여 신청서",
+            "신분증",
+        ]
+
+    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_missing_trgter_indvdl_passes_empty_list_to_infer(
+        self, mock_get_detail, mock_infer
+    ):
+        """trgter_indvdl 없는 응답 → 빈 리스트로 _infer_missing_fields 호출."""
+        detail_without_trgter = {
+            k: v for k, v in _DUMMY_DETAIL.items() if k != "trgter_indvdl"
+        }
+        mock_get_detail.return_value = detail_without_trgter
+        mock_infer.return_value = []
+
+        await rag_detail_node(_make_state())
+
+        call_kwargs = mock_infer.call_args.kwargs
+        assert call_kwargs["trgter_indvdl"] == []
+
 
 class TestInferMissingFields:
     """_infer_missing_fields 단위 테스트 — get_llm만 mock."""
 
     @patch("agents.rag_detail.get_llm")
     async def test_returns_fields_not_in_profile(self, mock_get_llm):
-        from agents.rag_detail import _infer_missing_fields, _RequiredFields
-
         extractor = AsyncMock()
         extractor.ainvoke = AsyncMock(
             return_value=_RequiredFields(
@@ -203,8 +240,6 @@ class TestInferMissingFields:
 
     @patch("agents.rag_detail.get_llm")
     async def test_skips_already_filled_fields(self, mock_get_llm):
-        from agents.rag_detail import _infer_missing_fields, _RequiredFields
-
         extractor = AsyncMock()
         extractor.ainvoke = AsyncMock(
             return_value=_RequiredFields(
@@ -227,9 +262,49 @@ class TestInferMissingFields:
         assert "is_veteran" in result
 
     @patch("agents.rag_detail.get_llm")
-    async def test_extra_fields_prefixed_correctly(self, mock_get_llm):
-        from agents.rag_detail import _infer_missing_fields, _RequiredFields
+    async def test_skips_invalid_field_names_not_in_stage2(self, mock_get_llm):
+        """LLM이 _STAGE_2_FIELDS에 없는 필드명 반환 → 제외."""
+        extractor = AsyncMock()
+        extractor.ainvoke = AsyncMock(
+            return_value=_RequiredFields(
+                regular_fields=["invalid_field", "nonexistent_key", "housing_type"],
+                extra_fields=[],
+            )
+        )
+        mock_get_llm.return_value.with_structured_output.return_value = extractor
 
+        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
+        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
+
+        assert "invalid_field" not in result
+        assert "nonexistent_key" not in result
+        assert "housing_type" in result
+
+    @patch("agents.rag_detail.get_llm")
+    async def test_skips_extra_fields_already_in_profile(self, mock_get_llm):
+        """LLM이 profile.extra_fields에 이미 있는 키 반환 → 제외."""
+        extractor = AsyncMock()
+        extractor.ainvoke = AsyncMock(
+            return_value=_RequiredFields(
+                regular_fields=[],
+                extra_fields=["deposit_amount", "existing_key"],
+            )
+        )
+        mock_get_llm.return_value.with_structured_output.return_value = extractor
+
+        profile = UserProfile(
+            age=65,
+            income_level=IncomeLevel.BASIC,
+            disability=False,
+            extra_fields={"existing_key": "some_value"},  # already in profile
+        )
+        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
+
+        assert "extra:deposit_amount" in result
+        assert "extra:existing_key" not in result
+
+    @patch("agents.rag_detail.get_llm")
+    async def test_extra_fields_prefixed_correctly(self, mock_get_llm):
         extractor = AsyncMock()
         extractor.ainvoke = AsyncMock(
             return_value=_RequiredFields(
@@ -245,7 +320,19 @@ class TestInferMissingFields:
 
     @patch("agents.rag_detail.get_llm")
     async def test_llm_failure_returns_empty_list(self, mock_get_llm):
-        from agents.rag_detail import _infer_missing_fields
+        extractor = AsyncMock()
+        extractor.ainvoke = AsyncMock(side_effect=Exception("LLM error"))
+        mock_get_llm.return_value.with_structured_output.return_value = extractor
+
+        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
+        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
+
+        assert result == []
+
+    @patch("agents.rag_detail.get_llm")
+    async def test_llm_failure_retries_max_retry_plus_one_times(self, mock_get_llm):
+        """모든 시도 실패 → LLM_MAX_RETRY+1회 시도 후 빈 리스트 반환."""
+        max_retry = int(os.getenv("LLM_MAX_RETRY", "2"))
 
         extractor = AsyncMock()
         extractor.ainvoke = AsyncMock(side_effect=Exception("LLM error"))
@@ -253,5 +340,55 @@ class TestInferMissingFields:
 
         profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
         result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
+
+        assert result == []
+        assert extractor.ainvoke.call_count == max_retry + 1
+
+    @patch("agents.rag_detail.get_llm")
+    async def test_first_attempt_fails_second_succeeds(self, mock_get_llm):
+        """첫 시도 실패 후 두 번째에 성공 → 정상 반환."""
+        extractor = AsyncMock()
+        extractor.ainvoke = AsyncMock(
+            side_effect=[
+                Exception("일시 오류"),
+                _RequiredFields(regular_fields=["is_veteran"], extra_fields=[]),
+            ]
+        )
+        mock_get_llm.return_value.with_structured_output.return_value = extractor
+
+        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
+        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
+
+        assert "is_veteran" in result
+        assert extractor.ainvoke.call_count == 2
+
+    @patch("agents.rag_detail.get_llm")
+    async def test_empty_eligibility_text_still_calls_llm(self, mock_get_llm):
+        """빈 eligibility 텍스트 입력 → LLM 호출은 하되 결과에 따라 반환."""
+        extractor = AsyncMock()
+        extractor.ainvoke = AsyncMock(
+            return_value=_RequiredFields(regular_fields=[], extra_fields=[])
+        )
+        mock_get_llm.return_value.with_structured_output.return_value = extractor
+
+        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
+        result = await _infer_missing_fields(profile, "", "", [])
+
+        assert extractor.ainvoke.call_count == 1
+        assert result == []
+
+    @patch("agents.rag_detail.get_llm")
+    async def test_both_fields_empty_returns_empty_list(self, mock_get_llm):
+        """regular_fields와 extra_fields 모두 비어있는 반환 → 빈 리스트."""
+        extractor = AsyncMock()
+        extractor.ainvoke = AsyncMock(
+            return_value=_RequiredFields(regular_fields=[], extra_fields=[])
+        )
+        mock_get_llm.return_value.with_structured_output.return_value = extractor
+
+        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
+        result = await _infer_missing_fields(
+            profile, "대상자", "선정기준", ["저소득층"]
+        )
 
         assert result == []

--- a/tests/test_rag_detail.py
+++ b/tests/test_rag_detail.py
@@ -53,13 +53,20 @@ _DUMMY_DETAIL = {
     "required_documents": ["사회보장급여 신청서", "신분증"],
     "application_fields": ["신청인 성명", "주소"],
     "application_url": "https://www.bokjiro.go.kr",
+    "tgtr_dtl_cn": "기초생활수급자 중 생계급여 수급자",
+    "slct_crit_cn": "소득인정액이 생계급여 선정기준 이하인 자",
+    "trgter_indvdl": ["저소득층"],
 }
 
 
 class TestRagDetailNode:
+    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
     @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
-    async def test_updates_selected_service_on_success(self, mock_get_detail):
+    async def test_updates_selected_service_on_success(
+        self, mock_get_detail, mock_infer
+    ):
         mock_get_detail.return_value = _DUMMY_DETAIL
+        mock_infer.return_value = []
 
         result = await rag_detail_node(_make_state())
 
@@ -69,9 +76,13 @@ class TestRagDetailNode:
         assert updated.application_fields == ["신청인 성명", "주소"]
         assert updated.application_url == "https://www.bokjiro.go.kr"
 
+    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
     @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
-    async def test_preserves_existing_fields_on_success(self, mock_get_detail):
+    async def test_preserves_existing_fields_on_success(
+        self, mock_get_detail, mock_infer
+    ):
         mock_get_detail.return_value = _DUMMY_DETAIL
+        mock_infer.return_value = []
 
         result = await rag_detail_node(_make_state())
 
@@ -111,11 +122,25 @@ class TestRagDetailNode:
         assert result["selected_service"].serv_id == original.serv_id
 
     @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
-    async def test_missing_optional_fields_default_to_empty(self, mock_get_detail):
+    async def test_network_error_returns_empty_detail_missing_fields(
+        self, mock_get_detail
+    ):
+        mock_get_detail.side_effect = Exception("Connection error")
+
+        result = await rag_detail_node(_make_state())
+
+        assert result["detail_missing_fields"] == []
+
+    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_missing_optional_fields_default_to_empty(
+        self, mock_get_detail, mock_infer
+    ):
         mock_get_detail.return_value = {
             "serv_id": "WLF-001",
             "serv_nm": "기초생활수급자 생계급여",
         }
+        mock_infer.return_value = []
 
         result = await rag_detail_node(_make_state())
 
@@ -124,3 +149,109 @@ class TestRagDetailNode:
         assert updated.application_fields == []
         assert updated.application_url is None
         assert updated.detail_fetched is True
+
+    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_sets_detail_missing_fields_from_llm(
+        self, mock_get_detail, mock_infer
+    ):
+        mock_get_detail.return_value = _DUMMY_DETAIL
+        mock_infer.return_value = ["housing_type", "is_veteran"]
+
+        result = await rag_detail_node(_make_state())
+
+        assert result["detail_missing_fields"] == ["housing_type", "is_veteran"]
+
+    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_passes_eligibility_fields_to_infer(
+        self, mock_get_detail, mock_infer
+    ):
+        mock_get_detail.return_value = _DUMMY_DETAIL
+        mock_infer.return_value = []
+
+        await rag_detail_node(_make_state())
+
+        call_kwargs = mock_infer.call_args.kwargs
+        assert call_kwargs["tgtr_dtl_cn"] == _DUMMY_DETAIL["tgtr_dtl_cn"]
+        assert call_kwargs["slct_crit_cn"] == _DUMMY_DETAIL["slct_crit_cn"]
+        assert call_kwargs["trgter_indvdl"] == _DUMMY_DETAIL["trgter_indvdl"]
+
+
+class TestInferMissingFields:
+    """_infer_missing_fields 단위 테스트 — get_llm만 mock."""
+
+    @patch("agents.rag_detail.get_llm")
+    async def test_returns_fields_not_in_profile(self, mock_get_llm):
+        from agents.rag_detail import _infer_missing_fields, _RequiredFields
+
+        extractor = AsyncMock()
+        extractor.ainvoke = AsyncMock(
+            return_value=_RequiredFields(
+                regular_fields=["housing_type", "is_veteran"], extra_fields=[]
+            )
+        )
+        mock_get_llm.return_value.with_structured_output.return_value = extractor
+
+        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
+        result = await _infer_missing_fields(
+            profile, "대상자", "선정기준", ["저소득층"]
+        )
+
+        assert "housing_type" in result
+        assert "is_veteran" in result
+
+    @patch("agents.rag_detail.get_llm")
+    async def test_skips_already_filled_fields(self, mock_get_llm):
+        from agents.rag_detail import _infer_missing_fields, _RequiredFields
+
+        extractor = AsyncMock()
+        extractor.ainvoke = AsyncMock(
+            return_value=_RequiredFields(
+                regular_fields=["housing_type", "is_veteran"], extra_fields=[]
+            )
+        )
+        mock_get_llm.return_value.with_structured_output.return_value = extractor
+
+        profile = UserProfile(
+            age=65,
+            income_level=IncomeLevel.BASIC,
+            disability=False,
+            housing_type="아파트",  # already filled
+        )
+        result = await _infer_missing_fields(
+            profile, "대상자", "선정기준", ["저소득층"]
+        )
+
+        assert "housing_type" not in result
+        assert "is_veteran" in result
+
+    @patch("agents.rag_detail.get_llm")
+    async def test_extra_fields_prefixed_correctly(self, mock_get_llm):
+        from agents.rag_detail import _infer_missing_fields, _RequiredFields
+
+        extractor = AsyncMock()
+        extractor.ainvoke = AsyncMock(
+            return_value=_RequiredFields(
+                regular_fields=[], extra_fields=["deposit_amount"]
+            )
+        )
+        mock_get_llm.return_value.with_structured_output.return_value = extractor
+
+        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
+        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
+
+        assert "extra:deposit_amount" in result
+
+    @patch("agents.rag_detail.get_llm")
+    async def test_llm_failure_returns_empty_list(self, mock_get_llm):
+        from agents.rag_detail import _infer_missing_fields
+
+        extractor = AsyncMock()
+        extractor.ainvoke = AsyncMock(side_effect=Exception("LLM error"))
+        mock_get_llm.return_value.with_structured_output.return_value = extractor
+
+        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
+        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
+
+        assert result == []


### PR DESCRIPTION
## 📝 PR 설명

- `rag_detail_node`에서 RAG 응답의 자격 요건 텍스트를 LLM으로 분석하여 `detail_missing_fields`를 자동 설정하는 로직 구현
- 기존에는 `detail_missing_fields`가 항상 빈 리스트로 유지되어 2단계 인터뷰 전체가 skip되는 버그 수정

## 🛠️ 작업 상세 내용

- `agents/rag_detail.py`: `_infer_missing_fields()` 추가 — `tgtr_dtl_cn`, `slct_crit_cn`, `trgter_indvdl`를 LLM structured output으로 분석하여 2단계 UserProfile 누락 필드 추론
- `rag_detail_node` 반환값에 `detail_missing_fields` 포함 (기존 누락)
- `UserProfile` 정규 필드에 있으면 필드명, 없으면 `extra:` 접두사로 추가
- LLM 실패 시 빈 리스트 fallback (파이프라인 중단 없음)

## 🧪 테스트 여부 및 확인 내용

- 21개 테스트 전체 통과 (기존 13개 → 21개로 확장)
- `_infer_missing_fields`: 무효 필드명 필터링, 중복 extra_fields 방지, 재시도 횟수 검증 등 모든 케이스 포함
- `rag_detail_node`: RAG 재시도 로직, trgter_indvdl 누락 fallback 등 포함
- `uv run ruff check` lint 클린

## 💬 기타 / 참고사항

- RAG 응답의 `tgtr_dtl_cn`, `slct_crit_cn`, `trgter_indvdl`는 현재 RAG API에서 정상 반환됨 (확인 완료)
- `application_fields` / `required_documents` 미구현 문제는 별개 이슈 (RAG팀 담당)

## 🔗 연관 이슈

- Closes #39
- 해당 PR이 머지되면 이슈가 자동으로 닫힙니다.