### PR TITLE
Feat/phase4

### DIFF
--- a/agents/initial_interview.py
+++ b/agents/initial_interview.py
@@ -85,7 +85,7 @@ async def initial_interview_node(state: AgentState) -> dict:
     ai_msg = AIMessage(content=question)
     human_msg = HumanMessage(content=user_answer)
 
-    if result.get("exist"):
+    if result.get("exist") and result.get("value") is not None:
         new_profile = _apply_value(state["user_profile"], field, result["value"])
         new_missing = _update_missing(field, new_profile, missing)
         return {

--- a/agents/rag_search.py
+++ b/agents/rag_search.py
@@ -59,14 +59,19 @@ async def rag_search_node(state: AgentState) -> dict:
 
     # RAG 호출 (1회 재시도)
     results = None
+    last_error = None
     for _ in range(2):
         try:
             results = await rag_client.search(
                 profile=_profile_to_dict(profile), top_k=top_k
             )
             break
-        except Exception:
+        except Exception as e:
+            last_error = e
             continue
+
+    if results is None and last_error is not None:
+        print(f"[RAG 오류] {type(last_error).__name__}: {last_error}")
 
     if results is None:
         error_msg = (

--- a/graph/builder.py
+++ b/graph/builder.py
@@ -3,6 +3,7 @@ from contextlib import AsyncExitStack
 
 from dotenv import load_dotenv
 from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.constants import END, START
 from langgraph.graph import StateGraph
 
@@ -46,7 +47,6 @@ def route_after_detail_interview(state: AgentState) -> str:
     return "document_guidance"
 
 
-
 # ── 그래프 빌더 ──
 
 
@@ -88,14 +88,32 @@ async def build_graph():
 
         db_path = os.getenv("SQLITE_DB_PATH", "./checkpoints.db")
         _checkpointer_stack = AsyncExitStack()
-        # enter_async_context: context manager를 "열어둔 채로" 스택에 등록
-        # 스택이 살아있는 한 DB 커넥션이 유지됨
         checkpointer = await _checkpointer_stack.enter_async_context(
             AsyncSqliteSaver.from_conn_string(db_path)
+        )
+        checkpointer.serde = JsonPlusSerializer(
+            allowed_msgpack_modules=[
+                ("graph.state", "UserProfile"),
+                ("graph.state", "WelfareCandidate"),
+                ("graph.state", "IncomeLevel"),
+                ("graph.state", "EmploymentStatus"),
+                ("graph.state", "MaritalStatus"),
+                ("graph.state", "DisabilitySeverity"),
+            ]
         )
         return builder.compile(checkpointer=checkpointer)
 
     if mode == "postgres":
         raise NotImplementedError("Postgres checkpointer is not configured yet.")
 
-    return builder.compile(checkpointer=MemorySaver())
+    serde = JsonPlusSerializer(
+        allowed_msgpack_modules=[
+            ("graph.state", "UserProfile"),
+            ("graph.state", "WelfareCandidate"),
+            ("graph.state", "IncomeLevel"),
+            ("graph.state", "EmploymentStatus"),
+            ("graph.state", "MaritalStatus"),
+            ("graph.state", "DisabilitySeverity"),
+        ]
+    )
+    return builder.compile(checkpointer=MemorySaver(serde=serde))

--- a/graph/builder.py
+++ b/graph/builder.py
@@ -46,6 +46,7 @@ def route_after_detail_interview(state: AgentState) -> str:
     return "document_guidance"
 
 
+
 # ── 그래프 빌더 ──
 
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
+import asyncio
 import uuid
 
 from dotenv import load_dotenv
+from langgraph.types import Command
 
 from graph.builder import graph
 from graph.state import UserProfile
@@ -8,12 +10,8 @@ from graph.state import UserProfile
 load_dotenv()
 
 
-def run():
-    """그래프 실행 진입점."""
-    thread_id = str(uuid.uuid4())
-    config = {"configurable": {"thread_id": thread_id}}
-
-    initial_state = {
+def _initial_state() -> dict:
+    return {
         "messages": [],
         "user_profile": UserProfile(),
         "initial_missing_fields": [
@@ -37,9 +35,59 @@ def run():
         "interview_last_answer": "",
     }
 
-    result = graph.invoke(initial_state, config)
-    return result
+
+async def _run_until_interrupt(input_: dict | Command, config: dict) -> tuple:
+    async for chunk in graph.astream(input_, config, stream_mode="updates"):
+        if "__interrupt__" in chunk:
+            interrupt_value = chunk["__interrupt__"][0].value
+            state = await graph.aget_state(config)
+            if "question" in interrupt_value:
+                return ("interview", interrupt_value, state)
+            if "candidates" in interrupt_value:
+                return ("service_select", interrupt_value, state)
+
+    state = await graph.aget_state(config)
+    if not state.values.get("welfare_candidates"):
+        return ("no_results", {}, state)
+    return ("done", {}, state)
+
+
+async def run():
+    """그래프 실행 진입점."""
+    thread_id = str(uuid.uuid4())
+    config = {"configurable": {"thread_id": thread_id}}
+
+    print("\n복지드림 AI 복지서비스 안내를 시작합니다.\n")
+
+    input_: dict | Command = _initial_state()
+
+    while True:
+        response_type, interrupt_value, state = await _run_until_interrupt(
+            input_, config
+        )
+
+        if response_type == "interview":
+            print(f"\n[복지드림] {interrupt_value['question']}")
+            user_input = input("> ").strip()
+            input_ = Command(resume=user_input)
+
+        elif response_type == "service_select":
+            print(f"\n[복지드림] {interrupt_value['candidates']}")
+            if interrupt_value.get("error"):
+                print(f"⚠ {interrupt_value['error']}")
+            user_input = input("> ").strip()
+            input_ = Command(resume=user_input)
+
+        elif response_type == "no_results":
+            print("\n[복지드림] 해당하는 복지서비스를 찾지 못했습니다.")
+            break
+
+        elif response_type == "done":
+            print("\n[복지드림] 안내가 완료되었습니다.\n")
+            print("=== 최종 보고서 ===")
+            print(state.values.get("final_report", ""))
+            break
 
 
 if __name__ == "__main__":
-    run()
+    asyncio.run(run())

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import uuid
 from dotenv import load_dotenv
 from langgraph.types import Command
 
-from graph.builder import graph
+from graph.builder import build_graph
 from graph.state import UserProfile
 
 load_dotenv()
@@ -36,7 +36,7 @@ def _initial_state() -> dict:
     }
 
 
-async def _run_until_interrupt(input_: dict | Command, config: dict) -> tuple:
+async def _run_until_interrupt(graph, input_: dict | Command, config: dict) -> tuple:
     async for chunk in graph.astream(input_, config, stream_mode="updates"):
         if "__interrupt__" in chunk:
             interrupt_value = chunk["__interrupt__"][0].value
@@ -54,6 +54,7 @@ async def _run_until_interrupt(input_: dict | Command, config: dict) -> tuple:
 
 async def run():
     """그래프 실행 진입점."""
+    graph = await build_graph()
     thread_id = str(uuid.uuid4())
     config = {"configurable": {"thread_id": thread_id}}
 
@@ -63,7 +64,7 @@ async def run():
 
     while True:
         response_type, interrupt_value, state = await _run_until_interrupt(
-            input_, config
+            graph, input_, config
         )
 
         if response_type == "interview":


### PR DESCRIPTION
  ## 📝 PR 설명

  - `main.py` CLI를 async 기반으로 전환하고, 그래프 인터럽트(인터뷰 / 서비스 선택)를 루프로 처리합니다.
  - LangGraph checkpointer가 커스텀 타입을 msgpack으로 직렬화할 수 있도록 허용 목록을 등록합니다.

  ## 🛠️ 작업 상세 내용

  - `main.py`
    - `run()` → `async def run()` 전환, 진입점을 `asyncio.run(run())`으로 변경
    - `_initial_state()` 헬퍼 분리
    - `_run_until_interrupt()` 추가: `graph.astream()`으로 스트리밍하며 `__interrupt__` 감지
    - `while True` 루프로 `interview` / `service_select` / `no_results` / `done` 4개 상태 분기 처리
  - `graph/builder.py`
    - `JsonPlusSerializer`에 커스텀 타입 허용 목록 등록 (`UserProfile`, `WelfareCandidate`, `IncomeLevel`, `EmploymentStatus`, `MaritalStatus`,
  `DisabilitySeverity`)
    - `MemorySaver` / `AsyncSqliteSaver` 양쪽에 `serde` 적용

  ## 🧪 테스트 여부 및 확인 내용

  - 기존 pytest 전체 통과 확인
  - CLI 실행(`uv run python main.py`) 후 인터뷰 → 서비스 선택 → 최종 보고서 흐름 수동 검증

  ## 📸 스크린샷 (선택)

  ## 💬 기타 / 참고사항

  - `GRAPH_CHECKPOINTER=memory`(dev) / `sqlite`(prod) 모두 serde 적용됨
  - interrupt 타입 구분: `"question"` 키 유무 → 인터뷰 / 서비스 선택

  ## 🔗 연관 이슈

  - Closes #41 
  - 해당 PR이 머지되면 이슈가 자동으로 닫힙니다.