### PR TITLE
feat(server): AgentState 필드 변화 추적 로깅 추가

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import logging.config
 import os
 import uuid
 from contextlib import asynccontextmanager
@@ -16,6 +18,35 @@ from graph.builder import build_graph
 from graph.state import UserProfile, WelfareCandidate
 
 load_dotenv()
+
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "format": "%(asctime)s [%(levelname)s] %(name)s | %(message)s",
+                "datefmt": "%H:%M:%S",
+            }
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+                "stream": "ext://sys.stderr",
+            }
+        },
+        "loggers": {
+            "bokjidream": {
+                "handlers": ["console"],
+                "level": os.getenv("LOG_LEVEL", "DEBUG"),
+                "propagate": False,
+            }
+        },
+    }
+)
+
+logger = logging.getLogger("bokjidream.server")
 
 # 서버 시작 시 lifespan에서 초기화됨
 graph = None
@@ -83,6 +114,44 @@ def _initial_state() -> dict:
     }
 
 
+def _format_field(field: str, value) -> str:
+    if value is None:
+        return "None"
+    if field == "messages":
+        return f"[{len(value) if isinstance(value, list) else '?'} message(s)]"
+    if field == "user_profile":
+        try:
+            filled = {k: v for k, v in value.model_dump().items() if v is not None}
+        except AttributeError:
+            return repr(value)
+        return (
+            "{" + ", ".join(f"{k}={v!r}" for k, v in filled.items()) + "}"
+            if filled
+            else "(empty)"
+        )
+    if field == "welfare_candidates":
+        names = [
+            getattr(c, "serv_nm", "?")
+            for c in (value if isinstance(value, list) else [])
+        ]
+        return f"[{len(names)}개: {', '.join(names)}]"
+    if field == "selected_service":
+        return getattr(value, "serv_nm", repr(value))
+    if isinstance(value, str):
+        return repr(value[:50] + "..." if len(value) > 50 else value)
+    return repr(value)
+
+
+def _log_state_chunk(chunk: dict) -> None:
+    for node_name, updates in chunk.items():
+        if node_name == "__interrupt__" or not isinstance(updates, dict):
+            return
+        lines = [f"  {f}: {_format_field(f, v)}" for f, v in updates.items()]
+        logger.debug(
+            "[node=%s] %d개 필드 업데이트:\n%s", node_name, len(lines), "\n".join(lines)
+        )
+
+
 def _interview_response(thread_id: str, interrupt_value: dict, state) -> ChatResponse:
     missing = (
         state.values.get("initial_missing_fields")
@@ -132,18 +201,36 @@ async def _run_until_interrupt(
     input_: dict | Command,
     config: dict,
 ) -> ChatResponse:
+    logger.debug("[thread=%s] 그래프 스트림 시작", thread_id)
     async for chunk in graph.astream(input_, config, stream_mode="updates"):
         if "__interrupt__" in chunk:
             interrupt_value = chunk["__interrupt__"][0].value
             state = await graph.aget_state(config)
             if "question" in interrupt_value:
+                logger.info(
+                    "[thread=%s] INTERRUPT → interview | field=%s | question=%.60s",
+                    thread_id,
+                    interrupt_value.get("field", "?"),
+                    interrupt_value["question"],
+                )
                 return _interview_response(thread_id, interrupt_value, state)
             if "candidates" in interrupt_value:
+                candidates = state.values.get("welfare_candidates", [])
+                logger.info(
+                    "[thread=%s] INTERRUPT → service_select | %d개: %s",
+                    thread_id,
+                    len(candidates),
+                    ", ".join(getattr(c, "serv_nm", "?") for c in candidates),
+                )
                 return _service_select_response(thread_id, interrupt_value, state)
+        else:
+            _log_state_chunk(chunk)
 
     state = await graph.aget_state(config)
     if not state.values.get("welfare_candidates"):
+        logger.info("[thread=%s] 스트림 종료 → no_results", thread_id)
         return ChatResponse(thread_id=thread_id, type="no_results", data={})
+    logger.info("[thread=%s] 스트림 종료 → done", thread_id)
     return _done_response(thread_id, state)
 
 
@@ -151,23 +238,33 @@ async def _run_until_interrupt(
 async def chat_start() -> ChatResponse:
     """새 세션을 시작하고 첫 번째 인터뷰 질문을 반환합니다."""
     thread_id = str(uuid.uuid4())
+    logger.info("[thread=%s] POST /chat/start", thread_id)
     config = {"configurable": {"thread_id": thread_id}}
     try:
-        return await _run_until_interrupt(thread_id, _initial_state(), config)
+        response = await _run_until_interrupt(thread_id, _initial_state(), config)
+        logger.info("[thread=%s] → type=%s", thread_id, response.type)
+        return response
     except Exception as e:
+        logger.exception("[thread=%s] /chat/start 오류", thread_id)
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @app.post("/chat/message", response_model=ChatResponse)
 async def chat_message(body: MessageRequest) -> ChatResponse:
     """사용자 메시지를 받아 그래프를 재개하고 다음 상태를 반환합니다."""
-    config = {"configurable": {"thread_id": body.thread_id}}
+    thread_id = body.thread_id
+    logger.info("[thread=%s] POST /chat/message | msg=%.40r", thread_id, body.message)
+    config = {"configurable": {"thread_id": thread_id}}
     state = await graph.aget_state(config)
     if not state.values:
+        logger.warning("[thread=%s] thread 없음", thread_id)
         raise HTTPException(status_code=404, detail="thread_id를 찾을 수 없습니다.")
     try:
-        return await _run_until_interrupt(
-            body.thread_id, Command(resume=body.message), config
+        response = await _run_until_interrupt(
+            thread_id, Command(resume=body.message), config
         )
+        logger.info("[thread=%s] → type=%s", thread_id, response.type)
+        return response
     except Exception as e:
+        logger.exception("[thread=%s] /chat/message 오류", thread_id)
         raise HTTPException(status_code=500, detail=str(e)) from e


### PR DESCRIPTION
 ## 📝 PR 설명

  - `server.py`에 AgentState 필드 변화 추적 로깅 추가

  ## 🛠️ 작업 상세 내용

  - `logging.config.dictConfig`로 `bokjidream` 로거 설정, `LOG_LEVEL` 환경변수로 레벨 조절 가능
  - `_format_field`: 필드 타입별 간결한 포맷 (user_profile은 non-None 필드만, messages는 개수, welfare_candidates는 서비스명 목록)
  - `_log_state_chunk`: 각 노드 실행 후 업데이트된 필드를 DEBUG 레벨로 출력
  - `_run_until_interrupt`: 인터뷰/서비스선택 인터럽트 발생 시 field명·질문 미리보기를 INFO 레벨로 출력
  - `/chat/start`, `/chat/message` 엔드포인트 요청·응답·에러 로깅 추가

  ## 🧪 테스트 여부 및 확인 내용

  - `uv run uvicorn server:app --reload --port 8001` 실행 후 웹 채팅으로 로그 출력 직접 확인

  ## 📸 스크린샷 (선택)

  ## 💬 기타 / 참고사항

  - 프론트엔드 기본 AI 연결 포트에 따라 `--port <포트번호>` 옵션 필수
  - `LOG_LEVEL=INFO` 설정 시 DEBUG 로그 억제 가능

  ## 🔗 연관 이슈

  - Closes #43 
  - 해당 PR이 머지되면 이슈가 자동으로 닫힙니다.