### PR TITLE
feat: re_ask=false 시에도 직전 대화 asker에 전달

### DIFF
--- a/agents/initial_interview.py
+++ b/agents/initial_interview.py
@@ -73,10 +73,8 @@ async def initial_interview_node(state: AgentState) -> dict:
         question = await hwnv_client.ask_question(
             field=field,
             re_ask=is_reask,
-            pre_assistant_message=state.get("interview_last_question", "")
-            if is_reask
-            else "",
-            pre_user_message=state.get("interview_last_answer", "") if is_reask else "",
+            pre_assistant_message=state.get("interview_last_question", ""),
+            pre_user_message=state.get("interview_last_answer", ""),
         )
     except Exception as e:
         print(f"[hwnv ask_question 오류] {type(e).__name__}: {e}")
@@ -110,8 +108,8 @@ async def initial_interview_node(state: AgentState) -> dict:
             "user_profile": new_profile,
             "initial_missing_fields": new_missing,
             "interview_current_field": None,
-            "interview_last_question": "",
-            "interview_last_answer": "",
+            "interview_last_question": question,
+            "interview_last_answer": user_answer,
         }
 
     # 추출 실패 또는 재질문 필요 → 다음 호출에서 re_ask=True로 재진입

--- a/test_live.py
+++ b/test_live.py
@@ -39,8 +39,8 @@ async def interview_field(field: str) -> tuple[str, object]:
         question = await ask_question(
             field=field,
             re_ask=is_reask,
-            pre_assistant_message=last_question if is_reask else "",
-            pre_user_message=last_answer if is_reask else "",
+            pre_assistant_message=last_question,
+            pre_user_message=last_answer,
         )
 
         user_answer = AUTO_ANSWERS[field]

--- a/tests/test_initial_interview.py
+++ b/tests/test_initial_interview.py
@@ -205,7 +205,7 @@ class TestInitialInterviewNodeExtraction:
     @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
     @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
     @patch("agents.initial_interview.interrupt", return_value="26살이요")
-    async def test_successful_reask_clears_tracking_fields(
+    async def test_successful_reask_keeps_last_exchange(
         self, mock_interrupt, mock_ask, mock_extract
     ):
         mock_ask.return_value = "나이를 숫자로 말씀해주세요."
@@ -225,8 +225,8 @@ class TestInitialInterviewNodeExtraction:
         result = await initial_interview_node(state)
 
         assert result["interview_current_field"] is None
-        assert result["interview_last_question"] == ""
-        assert result["interview_last_answer"] == ""
+        assert result["interview_last_question"] == "나이를 숫자로 말씀해주세요."
+        assert result["interview_last_answer"] == "26살이요"
 
 
 class TestDisabilitySeverityHandling:

--- a/tools/hwnv_client.py
+++ b/tools/hwnv_client.py
@@ -5,7 +5,7 @@ import json
 import httpx
 
 _BASE_URL = "https://hwnv.cloud"
-_TIMEOUT = 120.0
+_TIMEOUT = 300.0
 
 
 async def ask_question(
@@ -19,7 +19,7 @@ async def ask_question(
     Args:
         field: 수집할 항목 (age, region 등)
         re_ask: 재질문 여부
-        pre_assistant_message: 직전 봇 발화 (재질문 시 자연스러운 연결용)
+        pre_assistant_message: 직전 봇 발화
         pre_user_message: 직전 사용자 발화
 
     Returns:


### PR DESCRIPTION
## 📝 PR 설명

  - `re_ask=False`일 때도 직전 대화를 Asker에 전달하도록 수정

  ## 🛠️ 작업 상세 내용

  - `ask_question` 호출에서 `if is_reask else ""` 조건 제거 → 항상 state의 `interview_last_question` / `interview_last_answer` 전달
  - 필드 수집 성공 반환 시 `interview_last_question` / `interview_last_answer`를 `""`로 초기화하지 않고 직전 교환 내용으로 유지
  - `tools/hwnv_client.py` 독스트링 "재질문 시 자연스러운 연결용" 제한 문구 제거
  - `test_live.py` 동일 패턴 반영
  - `test_successful_reask_clears_tracking_fields` → `test_successful_reask_keeps_last_exchange`로 테스트 이름 및 단언 수정

  ## 🧪 테스트 여부 및 확인 내용

  - `tests/test_initial_interview.py` 19개 전체 통과

  ## 📸 스크린샷 (선택)

  ## 💬 기타 / 참고사항

  - 첫 번째 필드는 state에 이전 대화가 없으므로 빈 문자열 전달 → `hwnv_client`의 `if pre_assistant_message:` 조건에 의해 payload에서 자동 제외되어
  기존 동작 유지

  ## 🔗 연관 이슈

  - Closes #51 