### PR TITLE
fix: 서버 포트 번호 통일 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cp .env.example .env
 | `GROQ_MODEL` | `llama-3.3-70b-versatile` | 사용할 Groq 모델 |
 | `GRAPH_CHECKPOINTER` | `memory` | `memory` (개발) / `sqlite` (운영) |
 | `SQLITE_DB_PATH` | `./checkpoints.db` | SQLite 저장 경로 (sqlite 모드일 때) |
-| `RAG_SERVICE_URL` | `http://localhost:8000` | RAG 서버 주소 |
+| `RAG_SERVICE_URL` | `http://localhost:8001` | RAG 서버 주소 |
 | `RAG_SEARCH_TOP_K` | `5` | RAG 검색 후보 최대 수 |
 | `LLM_MAX_RETRY` | `2` | LLM 파싱 실패 시 최대 재시도 횟수 |
 | `HISTORY_WINDOW_SIZE` | `10` | LLM에 넘길 최근 대화 메시지 최대 개수 |
@@ -60,8 +60,8 @@ cp .env.example .env
 # 의존성 설치
 uv sync --all-groups
 
-# 서버 실행 (기본 포트 8001 — RAG 서버가 8000 사용 중)
-uv run uvicorn server:app --reload --port 8001
+# 서버 실행 (기본 포트 8000)
+uv run uvicorn server:app --reload --port 8000
 ```
 
 > RAG 서버가 별도로 실행 중이어야 합니다. `RAG_SERVICE_URL`을 RAG 서버 주소로 설정하세요.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -130,7 +130,7 @@ SQLITE_DB_PATH=./checkpoints.db        # GRAPH_CHECKPOINTER=sqlite 시 사용
 
 ```dotenv
 # RAG 서비스 연동
-RAG_SERVICE_URL=http://localhost:8000
+RAG_SERVICE_URL=http://localhost:8001
 RAG_SEARCH_TOP_K=5
 RAG_TIMEOUT_SECONDS=10                 # HTTP 타임아웃 (초)
 RAG_MAX_RETRIES=1                      # 네트워크 오류 재시도 횟수
@@ -140,7 +140,7 @@ RAG_MAX_RETRIES=1                      # 네트워크 오류 재시도 횟수
 
 ```dotenv
 # Ollama (로컬 LLM)
-OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_BASE_URL=http://localhost:8080
 OLLAMA_MODEL=llama3
 ```
 
@@ -149,7 +149,7 @@ OLLAMA_MODEL=llama3
 ```dotenv
 # FastAPI 서버 (Next.js 연동)
 SERVER_HOST=0.0.0.0
-SERVER_PORT=8001
+SERVER_PORT=8000
 ```
 
 ---

--- a/tools/rag_client.py
+++ b/tools/rag_client.py
@@ -8,7 +8,7 @@ _TIMEOUT = 10.0
 
 
 def _base_url() -> str:
-    return os.getenv("RAG_SERVICE_URL", "http://localhost:8000")
+    return os.getenv("RAG_SERVICE_URL", "http://localhost:8001")
 
 
 async def search(profile: dict, top_k: int | None = None) -> list[dict]:


### PR DESCRIPTION
## 📝 PR 설명

- AI 서버(8000)와 RAG 서버(8001) 포트 번호를 코드 전반에 통일

## 🛠️ 작업 상세 내용

- `tools/rag_client.py`: RAG 서버 기본 포트 8000 → 8001 수정
- `README.md`: 포트 번호 안내 업데이트
- `docs/reference.md`: 포트 번호 안내 업데이트

## 🧪 테스트 여부 및 확인 내용

- 로컬에서 AI 서버(8000), RAG 서버(8001) 구동 확인

## 📸 스크린샷 (선택)

## 💬 기타 / 참고사항

- 해당 없음

## 🔗 연관 이슈

- Closes #55