### PR TITLE
fix:interrupt resume 시 질문 API 중복 호출 방지

### DIFF
--- a/agents/detail_interview.py
+++ b/agents/detail_interview.py
@@ -6,7 +6,7 @@ import os
 from typing import TYPE_CHECKING
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
-from langgraph.types import interrupt
+from langgraph.types import Command, interrupt
 from pydantic import BaseModel
 
 from graph.state import UserProfile  # noqa: TCH001
@@ -150,7 +150,7 @@ async def _extract_profile(
     return new_profile, new_missing, False
 
 
-async def detail_interview_node(state: AgentState) -> dict:
+async def detail_interview_node(state: AgentState) -> dict | Command:
     """2단계 인터뷰: 선택된 서비스의 자격 요건 기반으로 특화 정보를 수집합니다."""
     profile = state["user_profile"]
     missing = list(state["detail_missing_fields"])
@@ -161,7 +161,14 @@ async def detail_interview_node(state: AgentState) -> dict:
 
     history = list(state["messages"])[-_HISTORY_WINDOW:]
 
-    question = await _generate_question(profile, missing, selected, history)
+    question = state.get("pending_question")
+    if question is None:
+        question = await _generate_question(profile, missing, selected, history)
+        return Command(
+            update={"pending_question": question},
+            goto="detail_interview",
+        )
+
     ai_message = AIMessage(content=question)
 
     user_answer: str = interrupt({"question": question, "missing_fields": missing})
@@ -181,4 +188,5 @@ async def detail_interview_node(state: AgentState) -> dict:
         "messages": messages,
         "user_profile": new_profile,
         "detail_missing_fields": new_missing,
+        "pending_question": None,
     }

--- a/agents/initial_interview.py
+++ b/agents/initial_interview.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from langchain_core.messages import AIMessage, HumanMessage
-from langgraph.types import interrupt
+from langgraph.types import Command, interrupt
 
 from graph.state import (  # noqa: TCH001
     DisabilitySeverity,
@@ -59,7 +59,7 @@ def _update_missing(
     return new_missing
 
 
-async def initial_interview_node(state: AgentState) -> dict:
+async def initial_interview_node(state: AgentState) -> dict | Command:
     """1단계 인터뷰: hwnv.cloud API로 필드별 질문·추출을 수행합니다."""
     missing = list(state["initial_missing_fields"])
     if not missing:
@@ -69,19 +69,29 @@ async def initial_interview_node(state: AgentState) -> dict:
     is_reask = current_field is not None
     field = current_field or missing[0]
 
-    try:
-        question = await hwnv_client.ask_question(
-            field=field,
-            re_ask=is_reask,
-            pre_assistant_message=state.get("interview_last_question", ""),
-            pre_user_message=state.get("interview_last_answer", ""),
+    # pending_question이 없으면 ask_question을 호출하고 state에 저장한 뒤 재진입.
+    # LangGraph는 resume 시 노드를 처음부터 재실행하므로, 저장해두지 않으면
+    # ask_question이 중복 호출된다.
+    question = state.get("pending_question")
+    if question is None:
+        try:
+            question = await hwnv_client.ask_question(
+                field=field,
+                re_ask=is_reask,
+                pre_assistant_message=state.get("interview_last_question", ""),
+                pre_user_message=state.get("interview_last_answer", ""),
+            )
+        except Exception as e:
+            print(f"[hwnv ask_question 오류] {type(e).__name__}: {e}")
+            error_msg = (
+                "죄송합니다. 질문 생성 중 오류가 발생했습니다. "
+                "잠시 후 다시 시도해 주세요."
+            )
+            return {"messages": [AIMessage(content=error_msg)]}
+        return Command(
+            update={"pending_question": question},
+            goto="initial_interview",
         )
-    except Exception as e:
-        print(f"[hwnv ask_question 오류] {type(e).__name__}: {e}")
-        error_msg = (
-            "죄송합니다. 질문 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
-        )
-        return {"messages": [AIMessage(content=error_msg)]}
 
     user_answer: str = interrupt({"question": question, "field": field})
 
@@ -89,12 +99,12 @@ async def initial_interview_node(state: AgentState) -> dict:
         result = await hwnv_client.extract_value(field, question, user_answer)
     except Exception as e:
         print(f"[hwnv extract_value 오류] {type(e).__name__}: {e}")
-        # 답변은 받았으나 추출 실패 → re_ask로 재진입
         return {
             "initial_missing_fields": missing,
             "interview_current_field": field,
             "interview_last_question": question,
             "interview_last_answer": user_answer,
+            "pending_question": None,
         }
 
     ai_msg = AIMessage(content=question)
@@ -110,13 +120,14 @@ async def initial_interview_node(state: AgentState) -> dict:
             "interview_current_field": None,
             "interview_last_question": question,
             "interview_last_answer": user_answer,
+            "pending_question": None,
         }
 
-    # 추출 실패 또는 재질문 필요 → 다음 호출에서 re_ask=True로 재진입
     return {
         "messages": [ai_msg, human_msg],
         "initial_missing_fields": missing,
         "interview_current_field": field,
         "interview_last_question": question,
         "interview_last_answer": user_answer,
+        "pending_question": None,
     }

--- a/graph/state.py
+++ b/graph/state.py
@@ -107,3 +107,6 @@ class AgentState(TypedDict):
     interview_current_field: str | None  # 현재 처리 중인 필드 (None=새 필드)
     interview_last_question: str  # 직전 봇 질문 (re_ask pre_assistant_message)
     interview_last_answer: str  # 직전 사용자 답변 (re_ask pre_user_message)
+    pending_question: (
+        str | None
+    )  # interrupt 전 생성된 질문 캐시 (resume 중복 호출 방지, 1·2단계 공용)

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import logging.config
 import os
+import time
 import uuid
 from contextlib import asynccontextmanager
 
@@ -111,6 +112,7 @@ def _initial_state() -> dict:
         "interview_current_field": None,
         "interview_last_question": "",
         "interview_last_answer": "",
+        "pending_question": None,
     }
 
 
@@ -202,10 +204,23 @@ async def _run_until_interrupt(
     config: dict,
 ) -> ChatResponse:
     logger.debug("[thread=%s] 그래프 스트림 시작", thread_id)
+    t_stream_start = time.perf_counter()
     async for chunk in graph.astream(input_, config, stream_mode="updates"):
         if "__interrupt__" in chunk:
+            t_interrupt = time.perf_counter()
+            logger.info(
+                "[thread=%s] [TIMING] stream→interrupt: %.3fs",
+                thread_id,
+                t_interrupt - t_stream_start,
+            )
             interrupt_value = chunk["__interrupt__"][0].value
+            t0 = time.perf_counter()
             state = await graph.aget_state(config)
+            logger.info(
+                "[thread=%s] [TIMING] aget_state (post-interrupt): %.3fs",
+                thread_id,
+                time.perf_counter() - t0,
+            )
             if "question" in interrupt_value:
                 logger.info(
                     "[thread=%s] INTERRUPT → interview | field=%s | question=%.60s",
@@ -255,7 +270,13 @@ async def chat_message(body: MessageRequest) -> ChatResponse:
     thread_id = body.thread_id
     logger.info("[thread=%s] POST /chat/message | msg=%.40r", thread_id, body.message)
     config = {"configurable": {"thread_id": thread_id}}
+    t0 = time.perf_counter()
     state = await graph.aget_state(config)
+    logger.info(
+        "[thread=%s] [TIMING] aget_state (pre-stream): %.3fs",
+        thread_id,
+        time.perf_counter() - t0,
+    )
     if not state.values:
         logger.warning("[thread=%s] thread 없음", thread_id)
         raise HTTPException(status_code=404, detail="thread_id를 찾을 수 없습니다.")

--- a/tests/test_detail_interview.py
+++ b/tests/test_detail_interview.py
@@ -51,14 +51,14 @@ class TestDetailInterviewNodeBasic:
         )
         with patch("agents.detail_interview.get_llm", return_value=mock_llm):
             with patch(
-                "agents.detail_interview.load_prompt", return_value="system prompt"
-            ):
-                with patch(
-                    "agents.detail_interview.interrupt",
-                    return_value="지체장애입니다",
-                ) as mock_interrupt:
-                    state = _base_state(detail_missing_fields=["disability_type"])
-                    await detail_interview_node(state)
+                "agents.detail_interview.interrupt",
+                return_value="지체장애입니다",
+            ) as mock_interrupt:
+                state = _base_state(
+                    detail_missing_fields=["disability_type"],
+                    pending_question="장애 유형이 어떻게 되세요?",
+                )
+                await detail_interview_node(state)
 
         mock_interrupt.assert_called_once()
         call_args = mock_interrupt.call_args[0][0]
@@ -72,14 +72,14 @@ class TestDetailInterviewNodeBasic:
         )
         with patch("agents.detail_interview.get_llm", return_value=mock_llm):
             with patch(
-                "agents.detail_interview.load_prompt", return_value="system prompt"
+                "agents.detail_interview.interrupt",
+                return_value="지체장애입니다",
             ):
-                with patch(
-                    "agents.detail_interview.interrupt",
-                    return_value="지체장애입니다",
-                ):
-                    state = _base_state(detail_missing_fields=["disability_type"])
-                    result = await detail_interview_node(state)
+                state = _base_state(
+                    detail_missing_fields=["disability_type"],
+                    pending_question="장애 유형이 어떻게 되세요?",
+                )
+                result = await detail_interview_node(state)
 
         msgs = result["messages"]
         assert any(isinstance(m, AIMessage) for m in msgs)
@@ -98,19 +98,17 @@ class TestDetailInterviewNodeExtraction:
         )
         with patch("agents.detail_interview.get_llm", return_value=mock_llm):
             with patch(
-                "agents.detail_interview.load_prompt", return_value="system prompt"
+                "agents.detail_interview.interrupt", return_value="지체장애, 자가"
             ):
-                with patch(
-                    "agents.detail_interview.interrupt", return_value="지체장애, 자가"
-                ):
-                    state = _base_state(
-                        detail_missing_fields=[
-                            "disability_type",
-                            "housing_type",
-                            "is_veteran",
-                        ]
-                    )
-                    result = await detail_interview_node(state)
+                state = _base_state(
+                    detail_missing_fields=[
+                        "disability_type",
+                        "housing_type",
+                        "is_veteran",
+                    ],
+                    pending_question="장애 유형과 주거 형태를 알려주세요.",
+                )
+                result = await detail_interview_node(state)
 
         assert "disability_type" not in result["detail_missing_fields"]
         assert "housing_type" not in result["detail_missing_fields"]
@@ -124,15 +122,13 @@ class TestDetailInterviewNodeExtraction:
         )
         with patch("agents.detail_interview.get_llm", return_value=mock_llm):
             with patch(
-                "agents.detail_interview.load_prompt", return_value="system prompt"
+                "agents.detail_interview.interrupt", return_value="지체장애, 자가"
             ):
-                with patch(
-                    "agents.detail_interview.interrupt", return_value="지체장애, 자가"
-                ):
-                    state = _base_state(
-                        detail_missing_fields=["disability_type", "housing_type"]
-                    )
-                    result = await detail_interview_node(state)
+                state = _base_state(
+                    detail_missing_fields=["disability_type", "housing_type"],
+                    pending_question="장애 유형과 주거 형태를 알려주세요.",
+                )
+                result = await detail_interview_node(state)
 
         profile = result["user_profile"]
         assert profile.disability_type == "지체장애"
@@ -146,14 +142,14 @@ class TestExtraFieldsHandling:
         )
         with patch("agents.detail_interview.get_llm", return_value=mock_llm):
             with patch(
-                "agents.detail_interview.load_prompt", return_value="system prompt"
+                "agents.detail_interview.interrupt",
+                return_value="참전용사입니다",
             ):
-                with patch(
-                    "agents.detail_interview.interrupt",
-                    return_value="참전용사입니다",
-                ):
-                    state = _base_state(detail_missing_fields=["extra:참전유공자"])
-                    result = await detail_interview_node(state)
+                state = _base_state(
+                    detail_missing_fields=["extra:참전유공자"],
+                    pending_question="국가보훈 대상이신가요?",
+                )
+                result = await detail_interview_node(state)
 
         assert result["user_profile"].extra_fields.get("참전유공자") is True
 
@@ -163,14 +159,14 @@ class TestExtraFieldsHandling:
         )
         with patch("agents.detail_interview.get_llm", return_value=mock_llm):
             with patch(
-                "agents.detail_interview.load_prompt", return_value="system prompt"
+                "agents.detail_interview.interrupt",
+                return_value="참전용사입니다",
             ):
-                with patch(
-                    "agents.detail_interview.interrupt",
-                    return_value="참전용사입니다",
-                ):
-                    state = _base_state(detail_missing_fields=["extra:참전유공자"])
-                    result = await detail_interview_node(state)
+                state = _base_state(
+                    detail_missing_fields=["extra:참전유공자"],
+                    pending_question="국가보훈 대상이신가요?",
+                )
+                result = await detail_interview_node(state)
 
         assert "extra:참전유공자" not in result["detail_missing_fields"]
 
@@ -179,12 +175,12 @@ class TestExtraFieldsHandling:
             return_value=_DetailExtraction()
         )
         with patch("agents.detail_interview.get_llm", return_value=mock_llm):
-            with patch(
-                "agents.detail_interview.load_prompt", return_value="system prompt"
-            ):
-                with patch("agents.detail_interview.interrupt", return_value="모름"):
-                    state = _base_state(detail_missing_fields=["extra:참전유공자"])
-                    result = await detail_interview_node(state)
+            with patch("agents.detail_interview.interrupt", return_value="모름"):
+                state = _base_state(
+                    detail_missing_fields=["extra:참전유공자"],
+                    pending_question="국가보훈 대상이신가요?",
+                )
+                result = await detail_interview_node(state)
 
         assert "extra:참전유공자" in result["detail_missing_fields"]
 

--- a/tests/test_detail_interview.py
+++ b/tests/test_detail_interview.py
@@ -45,19 +45,20 @@ class TestDetailInterviewNodeBasic:
         result = await detail_interview_node(state)
         assert result == {}
 
-    @patch("agents.detail_interview.interrupt", return_value="지체장애입니다")
-    @patch("agents.detail_interview.load_prompt", return_value="system prompt")
-    @patch("agents.detail_interview.get_llm")
-    async def test_interrupts_with_question(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
+    async def test_interrupts_with_question(self, mock_llm):
         mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
             return_value=_DetailExtraction(disability_type="지체장애")
         )
-
-        state = _base_state(detail_missing_fields=["disability_type"])
-        await detail_interview_node(state)
+        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+            with patch(
+                "agents.detail_interview.load_prompt", return_value="system prompt"
+            ):
+                with patch(
+                    "agents.detail_interview.interrupt",
+                    return_value="지체장애입니다",
+                ) as mock_interrupt:
+                    state = _base_state(detail_missing_fields=["disability_type"])
+                    await detail_interview_node(state)
 
         mock_interrupt.assert_called_once()
         call_args = mock_interrupt.call_args[0][0]
@@ -65,19 +66,20 @@ class TestDetailInterviewNodeBasic:
         assert "missing_fields" in call_args
         assert "disability_type" in call_args["missing_fields"]
 
-    @patch("agents.detail_interview.interrupt", return_value="지체장애입니다")
-    @patch("agents.detail_interview.load_prompt", return_value="system prompt")
-    @patch("agents.detail_interview.get_llm")
-    async def test_messages_contain_ai_and_human(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
+    async def test_messages_contain_ai_and_human(self, mock_llm):
         mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
             return_value=_DetailExtraction(disability_type="지체장애")
         )
-
-        state = _base_state(detail_missing_fields=["disability_type"])
-        result = await detail_interview_node(state)
+        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+            with patch(
+                "agents.detail_interview.load_prompt", return_value="system prompt"
+            ):
+                with patch(
+                    "agents.detail_interview.interrupt",
+                    return_value="지체장애입니다",
+                ):
+                    state = _base_state(detail_missing_fields=["disability_type"])
+                    result = await detail_interview_node(state)
 
         msgs = result["messages"]
         assert any(isinstance(m, AIMessage) for m in msgs)
@@ -88,43 +90,49 @@ class TestDetailInterviewNodeBasic:
 
 
 class TestDetailInterviewNodeExtraction:
-    @patch("agents.detail_interview.interrupt", return_value="지체장애, 자가")
-    @patch("agents.detail_interview.load_prompt", return_value="system prompt")
-    @patch("agents.detail_interview.get_llm")
-    async def test_extracted_fields_removed_from_missing(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
+    async def test_extracted_fields_removed_from_missing(self, mock_llm):
         mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
             return_value=_DetailExtraction(
                 disability_type="지체장애", housing_type="자가"
             )
         )
-
-        state = _base_state(
-            detail_missing_fields=["disability_type", "housing_type", "is_veteran"]
-        )
-        result = await detail_interview_node(state)
+        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+            with patch(
+                "agents.detail_interview.load_prompt", return_value="system prompt"
+            ):
+                with patch(
+                    "agents.detail_interview.interrupt", return_value="지체장애, 자가"
+                ):
+                    state = _base_state(
+                        detail_missing_fields=[
+                            "disability_type",
+                            "housing_type",
+                            "is_veteran",
+                        ]
+                    )
+                    result = await detail_interview_node(state)
 
         assert "disability_type" not in result["detail_missing_fields"]
         assert "housing_type" not in result["detail_missing_fields"]
         assert "is_veteran" in result["detail_missing_fields"]
 
-    @patch("agents.detail_interview.interrupt", return_value="지체장애, 자가")
-    @patch("agents.detail_interview.load_prompt", return_value="system prompt")
-    @patch("agents.detail_interview.get_llm")
-    async def test_profile_updated_with_extracted_fields(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
+    async def test_profile_updated_with_extracted_fields(self, mock_llm):
         mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
             return_value=_DetailExtraction(
                 disability_type="지체장애", housing_type="자가"
             )
         )
-
-        state = _base_state(detail_missing_fields=["disability_type", "housing_type"])
-        result = await detail_interview_node(state)
+        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+            with patch(
+                "agents.detail_interview.load_prompt", return_value="system prompt"
+            ):
+                with patch(
+                    "agents.detail_interview.interrupt", return_value="지체장애, 자가"
+                ):
+                    state = _base_state(
+                        detail_missing_fields=["disability_type", "housing_type"]
+                    )
+                    result = await detail_interview_node(state)
 
         profile = result["user_profile"]
         assert profile.disability_type == "지체장애"
@@ -132,51 +140,51 @@ class TestDetailInterviewNodeExtraction:
 
 
 class TestExtraFieldsHandling:
-    @patch("agents.detail_interview.interrupt", return_value="참전용사입니다")
-    @patch("agents.detail_interview.load_prompt", return_value="system prompt")
-    @patch("agents.detail_interview.get_llm")
-    async def test_extra_field_stored_in_extra_fields(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
+    async def test_extra_field_stored_in_extra_fields(self, mock_llm):
         mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
             return_value=_DetailExtraction(extra_fields={"참전유공자": True})
         )
-
-        state = _base_state(detail_missing_fields=["extra:참전유공자"])
-        result = await detail_interview_node(state)
+        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+            with patch(
+                "agents.detail_interview.load_prompt", return_value="system prompt"
+            ):
+                with patch(
+                    "agents.detail_interview.interrupt",
+                    return_value="참전용사입니다",
+                ):
+                    state = _base_state(detail_missing_fields=["extra:참전유공자"])
+                    result = await detail_interview_node(state)
 
         assert result["user_profile"].extra_fields.get("참전유공자") is True
 
-    @patch("agents.detail_interview.interrupt", return_value="참전용사입니다")
-    @patch("agents.detail_interview.load_prompt", return_value="system prompt")
-    @patch("agents.detail_interview.get_llm")
-    async def test_extra_field_removed_from_missing_after_extraction(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
+    async def test_extra_field_removed_from_missing_after_extraction(self, mock_llm):
         mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
             return_value=_DetailExtraction(extra_fields={"참전유공자": True})
         )
-
-        state = _base_state(detail_missing_fields=["extra:참전유공자"])
-        result = await detail_interview_node(state)
+        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+            with patch(
+                "agents.detail_interview.load_prompt", return_value="system prompt"
+            ):
+                with patch(
+                    "agents.detail_interview.interrupt",
+                    return_value="참전용사입니다",
+                ):
+                    state = _base_state(detail_missing_fields=["extra:참전유공자"])
+                    result = await detail_interview_node(state)
 
         assert "extra:참전유공자" not in result["detail_missing_fields"]
 
-    @patch("agents.detail_interview.interrupt", return_value="모름")
-    @patch("agents.detail_interview.load_prompt", return_value="system prompt")
-    @patch("agents.detail_interview.get_llm")
-    async def test_extra_field_remains_in_missing_when_not_extracted(
-        self, mock_get_llm, mock_load_prompt, mock_interrupt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
+    async def test_extra_field_remains_in_missing_when_not_extracted(self, mock_llm):
         mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
             return_value=_DetailExtraction()
         )
-
-        state = _base_state(detail_missing_fields=["extra:참전유공자"])
-        result = await detail_interview_node(state)
+        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+            with patch(
+                "agents.detail_interview.load_prompt", return_value="system prompt"
+            ):
+                with patch("agents.detail_interview.interrupt", return_value="모름"):
+                    state = _base_state(detail_missing_fields=["extra:참전유공자"])
+                    result = await detail_interview_node(state)
 
         assert "extra:참전유공자" in result["detail_missing_fields"]
 

--- a/tests/test_initial_interview.py
+++ b/tests/test_initial_interview.py
@@ -69,23 +69,21 @@ class TestInitialInterviewNodeBasic:
             "agents.initial_interview.interrupt", return_value="저는 40살이에요"
         ) as mock_interrupt:
             with patch(
-                "agents.initial_interview.hwnv_client.ask_question",
+                "agents.initial_interview.hwnv_client.extract_value",
                 new_callable=AsyncMock,
-            ) as mock_ask:
-                with patch(
-                    "agents.initial_interview.hwnv_client.extract_value",
-                    new_callable=AsyncMock,
-                ) as mock_extract:
-                    mock_ask.return_value = "나이가 어떻게 되세요?"
-                    mock_extract.return_value = {
-                        "exist": True,
-                        "value": 40,
-                        "re_ask": False,
-                        "reasoning": "",
-                    }
+            ) as mock_extract:
+                mock_extract.return_value = {
+                    "exist": True,
+                    "value": 40,
+                    "re_ask": False,
+                    "reasoning": "",
+                }
 
-                    state = _base_state(initial_missing_fields=["age"])
-                    await initial_interview_node(state)
+                state = _base_state(
+                    initial_missing_fields=["age"],
+                    pending_question="나이가 어떻게 되세요?",
+                )
+                await initial_interview_node(state)
 
         call_args = mock_interrupt.call_args[0][0]
         assert call_args["question"] == "나이가 어떻게 되세요?"
@@ -96,23 +94,21 @@ class TestInitialInterviewNodeBasic:
             "agents.initial_interview.interrupt", return_value="저는 40살이에요"
         ):
             with patch(
-                "agents.initial_interview.hwnv_client.ask_question",
+                "agents.initial_interview.hwnv_client.extract_value",
                 new_callable=AsyncMock,
-            ) as mock_ask:
-                with patch(
-                    "agents.initial_interview.hwnv_client.extract_value",
-                    new_callable=AsyncMock,
-                ) as mock_extract:
-                    mock_ask.return_value = "나이가 어떻게 되세요?"
-                    mock_extract.return_value = {
-                        "exist": True,
-                        "value": 40,
-                        "re_ask": False,
-                        "reasoning": "",
-                    }
+            ) as mock_extract:
+                mock_extract.return_value = {
+                    "exist": True,
+                    "value": 40,
+                    "re_ask": False,
+                    "reasoning": "",
+                }
 
-                    state = _base_state(initial_missing_fields=["age"])
-                    result = await initial_interview_node(state)
+                state = _base_state(
+                    initial_missing_fields=["age"],
+                    pending_question="나이가 어떻게 되세요?",
+                )
+                result = await initial_interview_node(state)
 
         msgs = result["messages"]
         assert any(isinstance(m, AIMessage) for m in msgs)
@@ -126,25 +122,21 @@ class TestInitialInterviewNodeExtraction:
     async def test_extracted_field_removed_from_missing(self):
         with patch("agents.initial_interview.interrupt", return_value="40살이에요"):
             with patch(
-                "agents.initial_interview.hwnv_client.ask_question",
+                "agents.initial_interview.hwnv_client.extract_value",
                 new_callable=AsyncMock,
-            ) as mock_ask:
-                with patch(
-                    "agents.initial_interview.hwnv_client.extract_value",
-                    new_callable=AsyncMock,
-                ) as mock_extract:
-                    mock_ask.return_value = "나이가 어떻게 되세요?"
-                    mock_extract.return_value = {
-                        "exist": True,
-                        "value": 40,
-                        "re_ask": False,
-                        "reasoning": "",
-                    }
+            ) as mock_extract:
+                mock_extract.return_value = {
+                    "exist": True,
+                    "value": 40,
+                    "re_ask": False,
+                    "reasoning": "",
+                }
 
-                    state = _base_state(
-                        initial_missing_fields=["age", "region", "income_level"]
-                    )
-                    result = await initial_interview_node(state)
+                state = _base_state(
+                    initial_missing_fields=["age", "region", "income_level"],
+                    pending_question="나이가 어떻게 되세요?",
+                )
+                result = await initial_interview_node(state)
 
         assert "age" not in result["initial_missing_fields"]
         assert "region" in result["initial_missing_fields"]
@@ -153,46 +145,42 @@ class TestInitialInterviewNodeExtraction:
     async def test_profile_updated_with_extracted_value(self):
         with patch("agents.initial_interview.interrupt", return_value="40살이에요"):
             with patch(
-                "agents.initial_interview.hwnv_client.ask_question",
+                "agents.initial_interview.hwnv_client.extract_value",
                 new_callable=AsyncMock,
-            ) as mock_ask:
-                with patch(
-                    "agents.initial_interview.hwnv_client.extract_value",
-                    new_callable=AsyncMock,
-                ) as mock_extract:
-                    mock_ask.return_value = "나이가 어떻게 되세요?"
-                    mock_extract.return_value = {
-                        "exist": True,
-                        "value": 40,
-                        "re_ask": False,
-                        "reasoning": "",
-                    }
+            ) as mock_extract:
+                mock_extract.return_value = {
+                    "exist": True,
+                    "value": 40,
+                    "re_ask": False,
+                    "reasoning": "",
+                }
 
-                    state = _base_state(initial_missing_fields=["age"])
-                    result = await initial_interview_node(state)
+                state = _base_state(
+                    initial_missing_fields=["age"],
+                    pending_question="나이가 어떻게 되세요?",
+                )
+                result = await initial_interview_node(state)
 
         assert result["user_profile"].age == 40
 
     async def test_extraction_failure_keeps_missing_and_sets_current_field(self):
         with patch("agents.initial_interview.interrupt", return_value="잘 모르겠어요"):
             with patch(
-                "agents.initial_interview.hwnv_client.ask_question",
+                "agents.initial_interview.hwnv_client.extract_value",
                 new_callable=AsyncMock,
-            ) as mock_ask:
-                with patch(
-                    "agents.initial_interview.hwnv_client.extract_value",
-                    new_callable=AsyncMock,
-                ) as mock_extract:
-                    mock_ask.return_value = "나이가 어떻게 되세요?"
-                    mock_extract.return_value = {
-                        "exist": False,
-                        "value": None,
-                        "re_ask": True,
-                        "reasoning": "불명확",
-                    }
+            ) as mock_extract:
+                mock_extract.return_value = {
+                    "exist": False,
+                    "value": None,
+                    "re_ask": True,
+                    "reasoning": "불명확",
+                }
 
-                    state = _base_state(initial_missing_fields=["age", "region"])
-                    result = await initial_interview_node(state)
+                state = _base_state(
+                    initial_missing_fields=["age", "region"],
+                    pending_question="나이가 어떻게 되세요?",
+                )
+                result = await initial_interview_node(state)
 
         assert "age" in result["initial_missing_fields"]
         assert result["interview_current_field"] == "age"
@@ -231,28 +219,24 @@ class TestInitialInterviewNodeExtraction:
     async def test_successful_reask_keeps_last_exchange(self):
         with patch("agents.initial_interview.interrupt", return_value="26살이요"):
             with patch(
-                "agents.initial_interview.hwnv_client.ask_question",
+                "agents.initial_interview.hwnv_client.extract_value",
                 new_callable=AsyncMock,
-            ) as mock_ask:
-                with patch(
-                    "agents.initial_interview.hwnv_client.extract_value",
-                    new_callable=AsyncMock,
-                ) as mock_extract:
-                    mock_ask.return_value = "나이를 숫자로 말씀해주세요."
-                    mock_extract.return_value = {
-                        "exist": True,
-                        "value": 26,
-                        "re_ask": False,
-                        "reasoning": "",
-                    }
+            ) as mock_extract:
+                mock_extract.return_value = {
+                    "exist": True,
+                    "value": 26,
+                    "re_ask": False,
+                    "reasoning": "",
+                }
 
-                    state = _base_state(
-                        initial_missing_fields=["age"],
-                        interview_current_field="age",
-                        interview_last_question="나이가 어떻게 되세요?",
-                        interview_last_answer="잘 모르겠어요",
-                    )
-                    result = await initial_interview_node(state)
+                state = _base_state(
+                    initial_missing_fields=["age"],
+                    interview_current_field="age",
+                    interview_last_question="나이가 어떻게 되세요?",
+                    interview_last_answer="잘 모르겠어요",
+                    pending_question="나이를 숫자로 말씀해주세요.",
+                )
+                result = await initial_interview_node(state)
 
         assert result["interview_current_field"] is None
         assert result["interview_last_question"] == "나이를 숫자로 말씀해주세요."
@@ -265,75 +249,65 @@ class TestDisabilitySeverityHandling:
             "agents.initial_interview.interrupt", return_value="장애가 있습니다"
         ):
             with patch(
-                "agents.initial_interview.hwnv_client.ask_question",
+                "agents.initial_interview.hwnv_client.extract_value",
                 new_callable=AsyncMock,
-            ) as mock_ask:
-                with patch(
-                    "agents.initial_interview.hwnv_client.extract_value",
-                    new_callable=AsyncMock,
-                ) as mock_extract:
-                    mock_ask.return_value = "장애가 있으신가요?"
-                    mock_extract.return_value = {
-                        "exist": True,
-                        "value": True,
-                        "re_ask": False,
-                        "reasoning": "",
-                    }
+            ) as mock_extract:
+                mock_extract.return_value = {
+                    "exist": True,
+                    "value": True,
+                    "re_ask": False,
+                    "reasoning": "",
+                }
 
-                    state = _base_state(initial_missing_fields=["disability"])
-                    result = await initial_interview_node(state)
+                state = _base_state(
+                    initial_missing_fields=["disability"],
+                    pending_question="장애가 있으신가요?",
+                )
+                result = await initial_interview_node(state)
 
         assert "disability_severity" in result["initial_missing_fields"]
 
     async def test_disability_false_removes_severity_from_missing(self):
         with patch("agents.initial_interview.interrupt", return_value="장애 없습니다"):
             with patch(
-                "agents.initial_interview.hwnv_client.ask_question",
+                "agents.initial_interview.hwnv_client.extract_value",
                 new_callable=AsyncMock,
-            ) as mock_ask:
-                with patch(
-                    "agents.initial_interview.hwnv_client.extract_value",
-                    new_callable=AsyncMock,
-                ) as mock_extract:
-                    mock_ask.return_value = "장애가 있으신가요?"
-                    mock_extract.return_value = {
-                        "exist": True,
-                        "value": False,
-                        "re_ask": False,
-                        "reasoning": "",
-                    }
+            ) as mock_extract:
+                mock_extract.return_value = {
+                    "exist": True,
+                    "value": False,
+                    "re_ask": False,
+                    "reasoning": "",
+                }
 
-                    state = _base_state(
-                        initial_missing_fields=["disability", "disability_severity"]
-                    )
-                    result = await initial_interview_node(state)
+                state = _base_state(
+                    initial_missing_fields=["disability", "disability_severity"],
+                    pending_question="장애가 있으신가요?",
+                )
+                result = await initial_interview_node(state)
 
         assert "disability_severity" not in result["initial_missing_fields"]
 
     async def test_disability_severity_collected_removes_from_missing(self):
         with patch("agents.initial_interview.interrupt", return_value="중증입니다"):
             with patch(
-                "agents.initial_interview.hwnv_client.ask_question",
+                "agents.initial_interview.hwnv_client.extract_value",
                 new_callable=AsyncMock,
-            ) as mock_ask:
-                with patch(
-                    "agents.initial_interview.hwnv_client.extract_value",
-                    new_callable=AsyncMock,
-                ) as mock_extract:
-                    mock_ask.return_value = "장애 정도가 어떻게 되세요?"
-                    mock_extract.return_value = {
-                        "exist": True,
-                        "value": "중증",
-                        "re_ask": False,
-                        "reasoning": "",
-                    }
+            ) as mock_extract:
+                mock_extract.return_value = {
+                    "exist": True,
+                    "value": "중증",
+                    "re_ask": False,
+                    "reasoning": "",
+                }
 
-                    profile = UserProfile(disability=True)
-                    state = _base_state(
-                        user_profile=profile,
-                        initial_missing_fields=["disability_severity"],
-                    )
-                    result = await initial_interview_node(state)
+                profile = UserProfile(disability=True)
+                state = _base_state(
+                    user_profile=profile,
+                    initial_missing_fields=["disability_severity"],
+                    pending_question="장애 정도가 어떻게 되세요?",
+                )
+                result = await initial_interview_node(state)
 
         assert "disability_severity" not in result["initial_missing_fields"]
         assert result["user_profile"].disability_severity == DisabilitySeverity.SEVERE

--- a/tests/test_initial_interview.py
+++ b/tests/test_initial_interview.py
@@ -64,43 +64,55 @@ class TestInitialInterviewNodeBasic:
             field="age", re_ask=False, pre_assistant_message="", pre_user_message=""
         )
 
-    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
-    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
-    @patch("agents.initial_interview.interrupt", return_value="저는 40살이에요")
-    async def test_interrupts_with_question_and_field(
-        self, mock_interrupt, mock_ask, mock_extract
-    ):
-        mock_ask.return_value = "나이가 어떻게 되세요?"
-        mock_extract.return_value = {
-            "exist": True,
-            "value": 40,
-            "re_ask": False,
-            "reasoning": "",
-        }
+    async def test_interrupts_with_question_and_field(self):
+        with patch(
+            "agents.initial_interview.interrupt", return_value="저는 40살이에요"
+        ) as mock_interrupt:
+            with patch(
+                "agents.initial_interview.hwnv_client.ask_question",
+                new_callable=AsyncMock,
+            ) as mock_ask:
+                with patch(
+                    "agents.initial_interview.hwnv_client.extract_value",
+                    new_callable=AsyncMock,
+                ) as mock_extract:
+                    mock_ask.return_value = "나이가 어떻게 되세요?"
+                    mock_extract.return_value = {
+                        "exist": True,
+                        "value": 40,
+                        "re_ask": False,
+                        "reasoning": "",
+                    }
 
-        state = _base_state(initial_missing_fields=["age"])
-        await initial_interview_node(state)
+                    state = _base_state(initial_missing_fields=["age"])
+                    await initial_interview_node(state)
 
         call_args = mock_interrupt.call_args[0][0]
         assert call_args["question"] == "나이가 어떻게 되세요?"
         assert call_args["field"] == "age"
 
-    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
-    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
-    @patch("agents.initial_interview.interrupt", return_value="저는 40살이에요")
-    async def test_messages_contain_ai_and_human(
-        self, mock_interrupt, mock_ask, mock_extract
-    ):
-        mock_ask.return_value = "나이가 어떻게 되세요?"
-        mock_extract.return_value = {
-            "exist": True,
-            "value": 40,
-            "re_ask": False,
-            "reasoning": "",
-        }
+    async def test_messages_contain_ai_and_human(self):
+        with patch(
+            "agents.initial_interview.interrupt", return_value="저는 40살이에요"
+        ):
+            with patch(
+                "agents.initial_interview.hwnv_client.ask_question",
+                new_callable=AsyncMock,
+            ) as mock_ask:
+                with patch(
+                    "agents.initial_interview.hwnv_client.extract_value",
+                    new_callable=AsyncMock,
+                ) as mock_extract:
+                    mock_ask.return_value = "나이가 어떻게 되세요?"
+                    mock_extract.return_value = {
+                        "exist": True,
+                        "value": 40,
+                        "re_ask": False,
+                        "reasoning": "",
+                    }
 
-        state = _base_state(initial_missing_fields=["age"])
-        result = await initial_interview_node(state)
+                    state = _base_state(initial_missing_fields=["age"])
+                    result = await initial_interview_node(state)
 
         msgs = result["messages"]
         assert any(isinstance(m, AIMessage) for m in msgs)
@@ -111,62 +123,76 @@ class TestInitialInterviewNodeBasic:
 
 
 class TestInitialInterviewNodeExtraction:
-    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
-    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
-    @patch("agents.initial_interview.interrupt", return_value="40살이에요")
-    async def test_extracted_field_removed_from_missing(
-        self, mock_interrupt, mock_ask, mock_extract
-    ):
-        mock_ask.return_value = "나이가 어떻게 되세요?"
-        mock_extract.return_value = {
-            "exist": True,
-            "value": 40,
-            "re_ask": False,
-            "reasoning": "",
-        }
+    async def test_extracted_field_removed_from_missing(self):
+        with patch("agents.initial_interview.interrupt", return_value="40살이에요"):
+            with patch(
+                "agents.initial_interview.hwnv_client.ask_question",
+                new_callable=AsyncMock,
+            ) as mock_ask:
+                with patch(
+                    "agents.initial_interview.hwnv_client.extract_value",
+                    new_callable=AsyncMock,
+                ) as mock_extract:
+                    mock_ask.return_value = "나이가 어떻게 되세요?"
+                    mock_extract.return_value = {
+                        "exist": True,
+                        "value": 40,
+                        "re_ask": False,
+                        "reasoning": "",
+                    }
 
-        state = _base_state(initial_missing_fields=["age", "region", "income_level"])
-        result = await initial_interview_node(state)
+                    state = _base_state(
+                        initial_missing_fields=["age", "region", "income_level"]
+                    )
+                    result = await initial_interview_node(state)
 
         assert "age" not in result["initial_missing_fields"]
         assert "region" in result["initial_missing_fields"]
         assert "income_level" in result["initial_missing_fields"]
 
-    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
-    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
-    @patch("agents.initial_interview.interrupt", return_value="40살이에요")
-    async def test_profile_updated_with_extracted_value(
-        self, mock_interrupt, mock_ask, mock_extract
-    ):
-        mock_ask.return_value = "나이가 어떻게 되세요?"
-        mock_extract.return_value = {
-            "exist": True,
-            "value": 40,
-            "re_ask": False,
-            "reasoning": "",
-        }
+    async def test_profile_updated_with_extracted_value(self):
+        with patch("agents.initial_interview.interrupt", return_value="40살이에요"):
+            with patch(
+                "agents.initial_interview.hwnv_client.ask_question",
+                new_callable=AsyncMock,
+            ) as mock_ask:
+                with patch(
+                    "agents.initial_interview.hwnv_client.extract_value",
+                    new_callable=AsyncMock,
+                ) as mock_extract:
+                    mock_ask.return_value = "나이가 어떻게 되세요?"
+                    mock_extract.return_value = {
+                        "exist": True,
+                        "value": 40,
+                        "re_ask": False,
+                        "reasoning": "",
+                    }
 
-        state = _base_state(initial_missing_fields=["age"])
-        result = await initial_interview_node(state)
+                    state = _base_state(initial_missing_fields=["age"])
+                    result = await initial_interview_node(state)
 
         assert result["user_profile"].age == 40
 
-    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
-    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
-    @patch("agents.initial_interview.interrupt", return_value="잘 모르겠어요")
-    async def test_extraction_failure_keeps_missing_and_sets_current_field(
-        self, mock_interrupt, mock_ask, mock_extract
-    ):
-        mock_ask.return_value = "나이가 어떻게 되세요?"
-        mock_extract.return_value = {
-            "exist": False,
-            "value": None,
-            "re_ask": True,
-            "reasoning": "불명확",
-        }
+    async def test_extraction_failure_keeps_missing_and_sets_current_field(self):
+        with patch("agents.initial_interview.interrupt", return_value="잘 모르겠어요"):
+            with patch(
+                "agents.initial_interview.hwnv_client.ask_question",
+                new_callable=AsyncMock,
+            ) as mock_ask:
+                with patch(
+                    "agents.initial_interview.hwnv_client.extract_value",
+                    new_callable=AsyncMock,
+                ) as mock_extract:
+                    mock_ask.return_value = "나이가 어떻게 되세요?"
+                    mock_extract.return_value = {
+                        "exist": False,
+                        "value": None,
+                        "re_ask": True,
+                        "reasoning": "불명확",
+                    }
 
-        state = _base_state(initial_missing_fields=["age", "region"])
-        result = await initial_interview_node(state)
+                    state = _base_state(initial_missing_fields=["age", "region"])
+                    result = await initial_interview_node(state)
 
         assert "age" in result["initial_missing_fields"]
         assert result["interview_current_field"] == "age"
@@ -202,27 +228,31 @@ class TestInitialInterviewNodeExtraction:
             pre_user_message="잘 모르겠어요",
         )
 
-    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
-    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
-    @patch("agents.initial_interview.interrupt", return_value="26살이요")
-    async def test_successful_reask_keeps_last_exchange(
-        self, mock_interrupt, mock_ask, mock_extract
-    ):
-        mock_ask.return_value = "나이를 숫자로 말씀해주세요."
-        mock_extract.return_value = {
-            "exist": True,
-            "value": 26,
-            "re_ask": False,
-            "reasoning": "",
-        }
+    async def test_successful_reask_keeps_last_exchange(self):
+        with patch("agents.initial_interview.interrupt", return_value="26살이요"):
+            with patch(
+                "agents.initial_interview.hwnv_client.ask_question",
+                new_callable=AsyncMock,
+            ) as mock_ask:
+                with patch(
+                    "agents.initial_interview.hwnv_client.extract_value",
+                    new_callable=AsyncMock,
+                ) as mock_extract:
+                    mock_ask.return_value = "나이를 숫자로 말씀해주세요."
+                    mock_extract.return_value = {
+                        "exist": True,
+                        "value": 26,
+                        "re_ask": False,
+                        "reasoning": "",
+                    }
 
-        state = _base_state(
-            initial_missing_fields=["age"],
-            interview_current_field="age",
-            interview_last_question="나이가 어떻게 되세요?",
-            interview_last_answer="잘 모르겠어요",
-        )
-        result = await initial_interview_node(state)
+                    state = _base_state(
+                        initial_missing_fields=["age"],
+                        interview_current_field="age",
+                        interview_last_question="나이가 어떻게 되세요?",
+                        interview_last_answer="잘 모르겠어요",
+                    )
+                    result = await initial_interview_node(state)
 
         assert result["interview_current_field"] is None
         assert result["interview_last_question"] == "나이를 숫자로 말씀해주세요."
@@ -230,66 +260,80 @@ class TestInitialInterviewNodeExtraction:
 
 
 class TestDisabilitySeverityHandling:
-    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
-    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
-    @patch("agents.initial_interview.interrupt", return_value="장애가 있습니다")
-    async def test_disability_true_adds_severity_to_missing(
-        self, mock_interrupt, mock_ask, mock_extract
-    ):
-        mock_ask.return_value = "장애가 있으신가요?"
-        mock_extract.return_value = {
-            "exist": True,
-            "value": True,
-            "re_ask": False,
-            "reasoning": "",
-        }
+    async def test_disability_true_adds_severity_to_missing(self):
+        with patch(
+            "agents.initial_interview.interrupt", return_value="장애가 있습니다"
+        ):
+            with patch(
+                "agents.initial_interview.hwnv_client.ask_question",
+                new_callable=AsyncMock,
+            ) as mock_ask:
+                with patch(
+                    "agents.initial_interview.hwnv_client.extract_value",
+                    new_callable=AsyncMock,
+                ) as mock_extract:
+                    mock_ask.return_value = "장애가 있으신가요?"
+                    mock_extract.return_value = {
+                        "exist": True,
+                        "value": True,
+                        "re_ask": False,
+                        "reasoning": "",
+                    }
 
-        state = _base_state(initial_missing_fields=["disability"])
-        result = await initial_interview_node(state)
+                    state = _base_state(initial_missing_fields=["disability"])
+                    result = await initial_interview_node(state)
 
         assert "disability_severity" in result["initial_missing_fields"]
 
-    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
-    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
-    @patch("agents.initial_interview.interrupt", return_value="장애 없습니다")
-    async def test_disability_false_removes_severity_from_missing(
-        self, mock_interrupt, mock_ask, mock_extract
-    ):
-        mock_ask.return_value = "장애가 있으신가요?"
-        mock_extract.return_value = {
-            "exist": True,
-            "value": False,
-            "re_ask": False,
-            "reasoning": "",
-        }
+    async def test_disability_false_removes_severity_from_missing(self):
+        with patch("agents.initial_interview.interrupt", return_value="장애 없습니다"):
+            with patch(
+                "agents.initial_interview.hwnv_client.ask_question",
+                new_callable=AsyncMock,
+            ) as mock_ask:
+                with patch(
+                    "agents.initial_interview.hwnv_client.extract_value",
+                    new_callable=AsyncMock,
+                ) as mock_extract:
+                    mock_ask.return_value = "장애가 있으신가요?"
+                    mock_extract.return_value = {
+                        "exist": True,
+                        "value": False,
+                        "re_ask": False,
+                        "reasoning": "",
+                    }
 
-        state = _base_state(
-            initial_missing_fields=["disability", "disability_severity"]
-        )
-        result = await initial_interview_node(state)
+                    state = _base_state(
+                        initial_missing_fields=["disability", "disability_severity"]
+                    )
+                    result = await initial_interview_node(state)
 
         assert "disability_severity" not in result["initial_missing_fields"]
 
-    @patch("agents.initial_interview.hwnv_client.extract_value", new_callable=AsyncMock)
-    @patch("agents.initial_interview.hwnv_client.ask_question", new_callable=AsyncMock)
-    @patch("agents.initial_interview.interrupt", return_value="중증입니다")
-    async def test_disability_severity_collected_removes_from_missing(
-        self, mock_interrupt, mock_ask, mock_extract
-    ):
-        mock_ask.return_value = "장애 정도가 어떻게 되세요?"
-        mock_extract.return_value = {
-            "exist": True,
-            "value": "중증",
-            "re_ask": False,
-            "reasoning": "",
-        }
+    async def test_disability_severity_collected_removes_from_missing(self):
+        with patch("agents.initial_interview.interrupt", return_value="중증입니다"):
+            with patch(
+                "agents.initial_interview.hwnv_client.ask_question",
+                new_callable=AsyncMock,
+            ) as mock_ask:
+                with patch(
+                    "agents.initial_interview.hwnv_client.extract_value",
+                    new_callable=AsyncMock,
+                ) as mock_extract:
+                    mock_ask.return_value = "장애 정도가 어떻게 되세요?"
+                    mock_extract.return_value = {
+                        "exist": True,
+                        "value": "중증",
+                        "re_ask": False,
+                        "reasoning": "",
+                    }
 
-        profile = UserProfile(disability=True)
-        state = _base_state(
-            user_profile=profile,
-            initial_missing_fields=["disability_severity"],
-        )
-        result = await initial_interview_node(state)
+                    profile = UserProfile(disability=True)
+                    state = _base_state(
+                        user_profile=profile,
+                        initial_missing_fields=["disability_severity"],
+                    )
+                    result = await initial_interview_node(state)
 
         assert "disability_severity" not in result["initial_missing_fields"]
         assert result["user_profile"].disability_severity == DisabilitySeverity.SEVERE


### PR DESCRIPTION
 ## 📝 PR 설명

  - LangGraph resume 시 질문 생성 API가 중복 호출되는 버그 수정

  ## 🛠️ 작업 상세 내용

  - **`graph/state.py`**: `pending_question: str | None` 추가 (1·2단계 인터뷰 공용 질문 캐시)
  - **`agents/initial_interview.py`**: `state.get("pending_question")` 확인 → None이면 `hwnv_client.ask_question()` 호출 후 `Command(update={"pending_question": ...}, goto="initial_interview")`로 재진입,
  resume 시 캐시 값으로 바로 `interrupt()` 진행
  - **`agents/detail_interview.py`**: 동일 패턴 적용, `_generate_question()` LLM 중복 호출 방지
  - **`server.py`**: `_initial_state()`에 `pending_question: None` 초기화, `time.perf_counter()` 기반 타이밍 로그 추가 (stream→interrupt, aget_state ×2)

  ## 🧪 테스트 여부 및 확인 내용

  - [ ] 1단계 인터뷰 정상 흐름 (질문 생성 → interrupt → resume → 추출)
  - [ ] 1단계 extract_value 실패 → re_ask 재진입
  - [ ] 2단계 인터뷰 정상 흐름
  - [ ] 타이밍 로그 출력 확인

  ## 💬 기타 / 참고사항

  - 타이밍 로그는 `INFO` 레벨, 응답 지연 원인 분석용

  ## 🔗 연관 이슈

  - Closes #57 