### PR TITLE
Feat/detail interview hwnv

### DIFF
--- a/agents/detail_interview.py
+++ b/agents/detail_interview.py
@@ -163,6 +163,17 @@ async def detail_interview_node(state: AgentState) -> dict | Command:
             "pending_question": None,
         }
 
+    if not result.get("re_ask"):
+        new_missing = [f for f in missing if f != field]
+        return {
+            "messages": [ai_msg, human_msg],
+            "detail_missing_fields": new_missing,
+            "detail_current_field": None,
+            "detail_last_question": question,
+            "detail_last_answer": user_answer,
+            "pending_question": None,
+        }
+
     return {
         "messages": [ai_msg, human_msg],
         "detail_missing_fields": missing,

--- a/agents/detail_interview.py
+++ b/agents/detail_interview.py
@@ -2,191 +2,172 @@
 
 from __future__ import annotations
 
-import os
+import re
 from typing import TYPE_CHECKING
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.types import Command, interrupt
-from pydantic import BaseModel
 
-from graph.state import UserProfile  # noqa: TCH001
-from tools.llm import get_llm
-from tools.prompt_loader import load_prompt
+from tools import hwnv_client
 
 if TYPE_CHECKING:
-    from graph.state import AgentState, WelfareCandidate
+    from graph.state import AgentState, UserProfile
 
-_FIELD_LABELS: dict[str, str] = {
-    "disability_type": "장애 유형",
-    "disability_grade": "장애 등급",
-    "children_ages": "자녀 나이",
-    "housing_type": "주거 형태",
-    "household_type": "가구 유형",
-    "is_veteran": "국가보훈 대상 여부",
-    "is_single_parent": "한부모 가정 여부",
+_FIELD_INFO: dict[str, dict] = {
+    "disability_type": {
+        "key": "disability_type",
+        "label": "장애 유형",
+        "type": "string",
+        "question_hint": "장애 유형(지체, 시각, 청각, 지적 등)을 부드럽게 물어보세요",
+    },
+    "disability_grade": {
+        "key": "disability_grade",
+        "label": "장애 등급",
+        "type": "string",
+        "question_hint": "장애 등급을 물어보세요",
+    },
+    "children_ages": {
+        "key": "children_ages",
+        "label": "자녀 나이",
+        "type": "string",
+        "question_hint": "자녀들의 나이를 모두 알려달라고 물어보세요",
+    },
+    "housing_type": {
+        "key": "housing_type",
+        "label": "주거 형태",
+        "type": "enum",
+        "enum_values": ["자가", "전세", "월세", "공공임대", "기타"],
+        "question_hint": "현재 주거 형태를 선택지로 물어보세요",
+    },
+    "household_type": {
+        "key": "household_type",
+        "label": "가구 유형",
+        "type": "string",
+        "question_hint": "가구 형태(1인 가구, 부부 가구, 조손 가구 등)를 물어보세요",
+    },
+    "is_veteran": {
+        "key": "is_veteran",
+        "label": "국가보훈 대상 여부",
+        "type": "bool",
+        "question_hint": "국가보훈처에 등록된 보훈 대상자인지 물어보세요",
+    },
+    "is_single_parent": {
+        "key": "is_single_parent",
+        "label": "한부모 가정 여부",
+        "type": "bool",
+        "question_hint": "한부모 가정(편부/편모 가정)에 해당하는지 물어보세요",
+    },
 }
 
-_MAX_RETRY = int(os.getenv("LLM_MAX_RETRY", "2"))
-_HISTORY_WINDOW = int(os.getenv("HISTORY_WINDOW_SIZE", "10"))
-_RETRY_MSG = "이해하지 못했습니다. 좀 더 구체적으로 말씀해주시겠어요?"
+
+def _get_field_info(field: str, extra_schemas: list[dict]) -> dict | None:
+    """필드명에 해당하는 field_info 딕셔너리를 반환합니다."""
+    if field in _FIELD_INFO:
+        return _FIELD_INFO[field]
+    if field.startswith("extra:"):
+        key = field.removeprefix("extra:")
+        return next((s for s in extra_schemas if s.get("key") == key), None)
+    return None
 
 
-class _DetailExtraction(BaseModel):
-    """structured output 스키마: 대화에서 추출된 2단계 프로필 필드."""
-
-    disability_type: str | None = None
-    disability_grade: str | None = None
-    children_ages: list[int] | None = None
-    housing_type: str | None = None
-    household_type: str | None = None
-    is_veteran: bool | None = None
-    is_single_parent: bool | None = None
-    extra_fields: dict[str, str | int | bool] = {}
-
-
-async def _generate_question(
+def _apply_extracted_value(
     profile: UserProfile,
-    missing: list[str],
-    selected: WelfareCandidate,
-    history: list,
-) -> str:
-    """선택된 서비스 자격 요건을 참고하여 누락 필드에 대한 질문을 생성합니다."""
-    system_prompt = load_prompt("detail_interview")
+    field: str,
+    value,
+) -> UserProfile:
+    """추출된 값을 UserProfile에 적용합니다."""
+    if field.startswith("extra:"):
+        key = field.removeprefix("extra:")
+        merged = {**profile.extra_fields, key: value}
+        return profile.model_copy(update={"extra_fields": merged})
 
-    missing_labels = [_FIELD_LABELS.get(f, f.removeprefix("extra:")) for f in missing]
-    collected = {
-        k: v
-        for k, v in profile.model_dump(exclude_none=True).items()
-        if k not in ("is_elderly", "extra_fields")
-    }
-    if profile.extra_fields:
-        collected["extra_fields"] = profile.extra_fields
+    if field == "children_ages" and isinstance(value, str):
+        ages = [int(m) for m in re.findall(r"\d+", value)]
+        value = ages if ages else None
 
-    instruction = (
-        f"[시스템] 선택된 서비스: {selected.serv_nm}\n"
-        f"[시스템] 서비스 설명: {selected.serv_dgst}\n"
-        f"[시스템] 아직 수집하지 못한 정보: {', '.join(missing_labels)}\n"
-        f"[시스템] 현재까지 파악된 정보: {collected}"
-    )
-    messages = [
-        SystemMessage(content=system_prompt),
-        *history,
-        HumanMessage(content=instruction),
-    ]
-    response = await get_llm().ainvoke(messages)
-    return response.content
-
-
-async def _extract_profile(
-    profile: UserProfile,
-    missing: list[str],
-    user_answer: str,
-    history: list,
-) -> tuple[UserProfile, list[str], bool]:
-    """사용자 답변에서 2단계 프로필 필드를 추출합니다.
-
-    실패 시 최대 LLM_MAX_RETRY회 재시도.
-    반환값: (profile, missing, extraction_failed)
-    - extraction_failed=True: 모든 재시도 소진, 기존 profile/missing 유지
-    "extra:KEY" 접두사 필드는 user_profile.extra_fields에 저장합니다.
-    """
-    regular_missing = [f for f in missing if not f.startswith("extra:")]
-    extra_missing = [f for f in missing if f.startswith("extra:")]
-    extra_keys_missing = [f.removeprefix("extra:") for f in extra_missing]
-
-    extract_system = (
-        "사용자의 답변에서 복지 서비스 신청용 개인 정보를 추출하세요.\n"
-        "사용자가 '없음', '없어', '없다', '아니오', '해당 없음' 등"
-        " 부정적 답변을 한 경우:\n"
-        "  - str 타입 필드면 '없음'으로 설정하세요\n"
-        "  - bool 타입 필드면 false로 설정하세요\n"
-        "진짜로 불확실한 경우에만 null로 두세요. 추론하거나 가정하지 마세요.\n"
-        f"추출 대상 필드: {', '.join(missing)}"
-    )
-    messages = [
-        SystemMessage(content=extract_system),
-        *history,
-        HumanMessage(content=user_answer),
-    ]
-
-    extractor = get_llm().with_structured_output(_DetailExtraction)
-    extraction: _DetailExtraction | None = None
-    for _ in range(_MAX_RETRY + 1):
-        try:
-            extraction = await extractor.ainvoke(messages)
-            break
-        except Exception:
-            continue
-
-    if extraction is None:
-        print(f"[DEBUG] extraction 완전 실패 (missing: {missing})")
-        return profile, missing, True
-
-    print(f"[DEBUG] 질문한 필드: {missing}")
-    print(f"[DEBUG] extraction 결과: {extraction.model_dump()}")
-
-    # 일반 필드 업데이트
-    regular_updates = {
-        k: v
-        for k, v in extraction.model_dump(exclude={"extra_fields"}).items()
-        if v is not None
-    }
-    new_profile = profile.model_copy(update=regular_updates)
-
-    # extra_fields 업데이트
-    if extraction.extra_fields:
-        merged_extra = {**new_profile.extra_fields, **extraction.extra_fields}
-        new_profile = new_profile.model_copy(update={"extra_fields": merged_extra})
-
-    # new_missing 계산
-    new_missing: list[str] = []
-    for field in regular_missing:
-        if getattr(new_profile, field, None) is None:
-            new_missing.append(field)
-    for key in extra_keys_missing:
-        if key not in new_profile.extra_fields:
-            new_missing.append(f"extra:{key}")
-
-    return new_profile, new_missing, False
+    if value is not None:
+        return profile.model_copy(update={field: value})
+    return profile
 
 
 async def detail_interview_node(state: AgentState) -> dict | Command:
-    """2단계 인터뷰: 선택된 서비스의 자격 요건 기반으로 특화 정보를 수집합니다."""
-    profile = state["user_profile"]
+    """2단계 인터뷰: hwnv detail_asker/detail_interviewer로 필드별 정보를 수집합니다."""
     missing = list(state["detail_missing_fields"])
-    selected = state["selected_service"]
-
     if not missing:
         return {}
 
-    history = list(state["messages"])[-_HISTORY_WINDOW:]
+    extra_schemas: list[dict] = state.get("extra_field_schemas", [])
+    current_field: str | None = state.get("detail_current_field")
+    is_reask = current_field is not None
+    field = current_field or missing[0]
+
+    field_info = _get_field_info(field, extra_schemas)
+    if field_info is None:
+        print(f"[DEBUG] 알 수 없는 2단계 필드 스킵: {field}")
+        return {"detail_missing_fields": [f for f in missing if f != field]}
 
     question = state.get("pending_question")
     if question is None:
-        question = await _generate_question(profile, missing, selected, history)
+        try:
+            question = await hwnv_client.ask_detail_question(
+                field_info=field_info,
+                re_ask=is_reask,
+                pre_assistant_message=state.get("detail_last_question", ""),
+                pre_user_message=state.get("detail_last_answer", ""),
+            )
+        except Exception as e:
+            print(f"[hwnv ask_detail_question 오류] {type(e).__name__}: {e}")
+            error_msg = (
+                "죄송합니다. 질문 생성 중 오류가 발생했습니다. "
+                "잠시 후 다시 시도해 주세요."
+            )
+            return {"messages": [AIMessage(content=error_msg)]}
         return Command(
             update={"pending_question": question},
             goto="detail_interview",
         )
 
-    ai_message = AIMessage(content=question)
+    user_answer: str = interrupt({"question": question, "field": field})
 
-    user_answer: str = interrupt({"question": question, "missing_fields": missing})
+    try:
+        result = await hwnv_client.extract_detail_value(
+            field_info, question, user_answer
+        )
+    except Exception as e:
+        print(f"[hwnv extract_detail_value 오류] {type(e).__name__}: {e}")
+        return {
+            "detail_missing_fields": missing,
+            "detail_current_field": field,
+            "detail_last_question": question,
+            "detail_last_answer": user_answer,
+            "pending_question": None,
+        }
 
-    new_profile, new_missing, extraction_failed = await _extract_profile(
-        profile,
-        missing,
-        user_answer,
-        (history + [ai_message])[-_HISTORY_WINDOW:],
-    )
+    ai_msg = AIMessage(content=question)
+    human_msg = HumanMessage(content=user_answer)
 
-    messages = [ai_message, HumanMessage(content=user_answer)]
-    if extraction_failed:
-        messages.append(AIMessage(content=_RETRY_MSG))
+    print(f"[DEBUG] 2단계 필드: {field}, 추출 결과: {result}")
+
+    if result.get("exist") and result.get("value") is not None:
+        new_profile = _apply_extracted_value(
+            state["user_profile"], field, result["value"]
+        )
+        new_missing = [f for f in missing if f != field]
+        return {
+            "messages": [ai_msg, human_msg],
+            "user_profile": new_profile,
+            "detail_missing_fields": new_missing,
+            "detail_current_field": None,
+            "detail_last_question": question,
+            "detail_last_answer": user_answer,
+            "pending_question": None,
+        }
 
     return {
-        "messages": messages,
-        "user_profile": new_profile,
-        "detail_missing_fields": new_missing,
+        "messages": [ai_msg, human_msg],
+        "detail_missing_fields": missing,
+        "detail_current_field": field,
+        "detail_last_question": question,
+        "detail_last_answer": user_answer,
         "pending_question": None,
     }

--- a/agents/rag_detail.py
+++ b/agents/rag_detail.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from pydantic import BaseModel
 
+import tools.hwnv_client as hwnv_client
 import tools.rag_client as rag_client
 from tools.llm import get_llm
 
@@ -128,7 +129,22 @@ async def rag_detail_node(state: AgentState) -> dict:
         trgter_indvdl=detail.get("trgter_indvdl", []),
     )
 
+    extra_field_schemas: list[dict] = []
+    if any(f.startswith("extra:") for f in missing_fields):
+        try:
+            extra_field_schemas = await hwnv_client.extract_extra_field_schemas(
+                {
+                    "serv_nm": detail.get("serv_nm", ""),
+                    "tgtr_dtl_cn": detail.get("tgtr_dtl_cn", ""),
+                    "slct_crit_cn": detail.get("slct_crit_cn", ""),
+                    "trgter_indvdl": detail.get("trgter_indvdl", []),
+                }
+            )
+        except Exception as e:
+            print(f"[hwnv field_extractor 오류] {type(e).__name__}: {e}")
+
     return {
         "selected_service": updated,
         "detail_missing_fields": missing_fields,
+        "extra_field_schemas": extra_field_schemas,
     }

--- a/agents/rag_detail.py
+++ b/agents/rag_detail.py
@@ -2,20 +2,15 @@
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
-from pydantic import BaseModel
+from langchain_core.messages import AIMessage
 
 import tools.hwnv_client as hwnv_client
 import tools.rag_client as rag_client
-from tools.llm import get_llm
 
 if TYPE_CHECKING:
     from graph.state import AgentState, UserProfile, WelfareCandidate
-
-_MAX_RETRY = int(os.getenv("LLM_MAX_RETRY", "2"))
 
 _STAGE_2_FIELDS = [
     "disability_type",
@@ -28,66 +23,36 @@ _STAGE_2_FIELDS = [
 ]
 
 
-class _RequiredFields(BaseModel):
-    regular_fields: list[str] = []
-    extra_fields: list[str] = []
-
-
-async def _infer_missing_fields(
+def _classify_schemas(
+    schemas: list[dict],
     profile: UserProfile,
-    tgtr_dtl_cn: str,
-    slct_crit_cn: str,
-    trgter_indvdl: list[str],
-) -> list[str]:
-    """자격 요건 텍스트에서 추가 수집이 필요한 UserProfile 필드를 추론합니다."""
-    system = (
-        "당신은 복지 서비스 자격 심사 전문가입니다.\n"
-        "주어진 서비스 자격 요건을 분석하여,"
-        " 사용자의 자격 여부 확인에 필요한 추가 정보를 결정하세요.\n\n"
-        f"수집 가능한 표준 필드 목록: {', '.join(_STAGE_2_FIELDS)}\n"
-        "규칙:\n"
-        "- 서비스 자격 요건에 필요한 표준 필드"
-        " → regular_fields에 필드명 추가\n"
-        "- 표준 필드에 없는 특수 정보가 필요한 경우"
-        " → extra_fields에 영문 snake_case 키 추가\n"
-        "- 현재 사용자 프로필에 이미 있는 정보는 포함하지 마세요\n\n"
-        f"현재 사용자 프로필: {profile.model_dump(exclude_none=True)}"
-    )
-    human = (
-        f"[대상자 상세]\n{tgtr_dtl_cn}\n\n"
-        f"[선정 기준]\n{slct_crit_cn}\n\n"
-        f"[대상자 유형]\n{', '.join(trgter_indvdl)}"
-    )
+) -> tuple[list[str], list[dict]]:
+    """field_extractor 결과를 표준 필드와 extra 필드로 분류합니다.
 
-    extractor = get_llm().with_structured_output(_RequiredFields)
-    result: _RequiredFields | None = None
-    for _ in range(_MAX_RETRY + 1):
-        try:
-            result = await extractor.ainvoke(
-                [SystemMessage(content=system), HumanMessage(content=human)]
-            )
-            break
-        except Exception:
-            continue
+    Returns:
+        (regular_missing, extra_schemas)
+        - regular_missing: _STAGE_2_FIELDS 중 아직 수집 안 된 것
+        - extra_schemas: 표준 필드에 없는 커스텀 필드 스키마 목록
+    """
+    regular_missing: list[str] = []
+    extra_schemas: list[dict] = []
 
-    if result is None:
-        return []
+    for schema in schemas:
+        key = schema.get("key", "")
+        if key in _STAGE_2_FIELDS:
+            if getattr(profile, key, None) is None:
+                regular_missing.append(key)
+        elif key not in profile.extra_fields:
+            extra_schemas.append(schema)
 
-    missing: list[str] = []
-    for field in result.regular_fields:
-        if field in _STAGE_2_FIELDS and getattr(profile, field, None) is None:
-            missing.append(field)
-    for key in result.extra_fields:
-        if key not in profile.extra_fields:
-            missing.append(f"extra:{key}")
-
-    # disability=False면 장애 관련 필드는 수집 불필요
     if not profile.disability:
-        missing = [
-            f for f in missing if f not in ("disability_type", "disability_grade")
+        regular_missing = [
+            f
+            for f in regular_missing
+            if f not in ("disability_type", "disability_grade")
         ]
 
-    return missing
+    return regular_missing, extra_schemas
 
 
 async def rag_detail_node(state: AgentState) -> dict:
@@ -110,6 +75,7 @@ async def rag_detail_node(state: AgentState) -> dict:
         return {
             "selected_service": selected,
             "detail_missing_fields": [],
+            "extra_field_schemas": [],
             "messages": [AIMessage(content=error_msg)],
         }
 
@@ -122,29 +88,24 @@ async def rag_detail_node(state: AgentState) -> dict:
         }
     )
 
-    missing_fields = await _infer_missing_fields(
-        profile=profile,
-        tgtr_dtl_cn=detail.get("tgtr_dtl_cn", ""),
-        slct_crit_cn=detail.get("slct_crit_cn", ""),
-        trgter_indvdl=detail.get("trgter_indvdl", []),
-    )
+    schemas: list[dict] = []
+    try:
+        schemas = await hwnv_client.extract_extra_field_schemas(
+            {
+                "serv_nm": detail.get("serv_nm", ""),
+                "tgtr_dtl_cn": detail.get("tgtr_dtl_cn", ""),
+                "slct_crit_cn": detail.get("slct_crit_cn", ""),
+                "trgter_indvdl": detail.get("trgter_indvdl", []),
+            }
+        )
+    except Exception as e:
+        print(f"[hwnv field_extractor 오류] {type(e).__name__}: {e}")
 
-    extra_field_schemas: list[dict] = []
-    if any(f.startswith("extra:") for f in missing_fields):
-        try:
-            extra_field_schemas = await hwnv_client.extract_extra_field_schemas(
-                {
-                    "serv_nm": detail.get("serv_nm", ""),
-                    "tgtr_dtl_cn": detail.get("tgtr_dtl_cn", ""),
-                    "slct_crit_cn": detail.get("slct_crit_cn", ""),
-                    "trgter_indvdl": detail.get("trgter_indvdl", []),
-                }
-            )
-        except Exception as e:
-            print(f"[hwnv field_extractor 오류] {type(e).__name__}: {e}")
+    regular_missing, extra_schemas = _classify_schemas(schemas, profile)
+    missing_fields = regular_missing + [f"extra:{s['key']}" for s in extra_schemas]
 
     return {
         "selected_service": updated,
         "detail_missing_fields": missing_fields,
-        "extra_field_schemas": extra_field_schemas,
+        "extra_field_schemas": extra_schemas,
     }

--- a/agents/rag_detail.py
+++ b/agents/rag_detail.py
@@ -23,6 +23,15 @@ _STAGE_2_FIELDS = [
 ]
 
 
+def _is_children_field(key: str, label: str) -> bool:
+    return (
+        "children" in key.lower()
+        or "child" in key.lower()
+        or "자녀" in label
+        or "아동" in label
+    )
+
+
 def _classify_schemas(
     schemas: list[dict],
     profile: UserProfile,
@@ -43,6 +52,10 @@ def _classify_schemas(
             if getattr(profile, key, None) is None:
                 regular_missing.append(key)
         elif key not in profile.extra_fields:
+            if profile.has_children is False and _is_children_field(
+                key, schema.get("label", "")
+            ):
+                continue
             extra_schemas.append(schema)
 
     if not profile.disability:

--- a/graph/state.py
+++ b/graph/state.py
@@ -110,3 +110,8 @@ class AgentState(TypedDict):
     pending_question: (
         str | None
     )  # interrupt 전 생성된 질문 캐시 (resume 중복 호출 방지, 1·2단계 공용)
+    # 2단계 인터뷰 재질문 추적 (detail_asker/detail_interviewer re_ask 흐름용)
+    detail_current_field: str | None  # 현재 처리 중인 필드 (None=새 필드)
+    detail_last_question: str  # 직전 2단계 봇 질문
+    detail_last_answer: str  # 직전 2단계 사용자 답변
+    extra_field_schemas: list[dict]  # field_extractor가 생성한 extra 필드 스키마

--- a/main.py
+++ b/main.py
@@ -33,6 +33,10 @@ def _initial_state() -> dict:
         "interview_current_field": None,
         "interview_last_question": "",
         "interview_last_answer": "",
+        "detail_current_field": None,
+        "detail_last_question": "",
+        "detail_last_answer": "",
+        "extra_field_schemas": [],
     }
 
 

--- a/server.py
+++ b/server.py
@@ -113,6 +113,10 @@ def _initial_state() -> dict:
         "interview_last_question": "",
         "interview_last_answer": "",
         "pending_question": None,
+        "detail_current_field": None,
+        "detail_last_question": "",
+        "detail_last_answer": "",
+        "extra_field_schemas": [],
     }
 
 

--- a/tests/test_detail_interview.py
+++ b/tests/test_detail_interview.py
@@ -1,13 +1,12 @@
 """2단계 인터뷰 에이전트 테스트."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from langchain_core.messages import AIMessage, HumanMessage
 
 from agents.detail_interview import (
-    _DetailExtraction,
-    _extract_profile,
-    _generate_question,
+    _apply_extracted_value,
+    _get_field_info,
     detail_interview_node,
 )
 from graph.state import IncomeLevel, UserProfile, WelfareCandidate
@@ -34,6 +33,11 @@ def _base_state(**overrides) -> dict:
         "document_guidance": "",
         "application_guide": "",
         "final_report": "",
+        "detail_current_field": None,
+        "detail_last_question": "",
+        "detail_last_answer": "",
+        "extra_field_schemas": [],
+        "pending_question": None,
     }
     state.update(overrides)
     return state
@@ -45,11 +49,27 @@ class TestDetailInterviewNodeBasic:
         result = await detail_interview_node(state)
         assert result == {}
 
-    async def test_interrupts_with_question(self, mock_llm):
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_DetailExtraction(disability_type="지체장애")
-        )
-        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+    async def test_generates_question_and_returns_command(self):
+        with patch(
+            "agents.detail_interview.hwnv_client.ask_detail_question",
+            new_callable=AsyncMock,
+            return_value="장애 유형이 어떻게 되세요?",
+        ):
+            state = _base_state(
+                detail_missing_fields=["disability_type"],
+                pending_question=None,
+            )
+            result = await detail_interview_node(state)
+
+        assert hasattr(result, "update")
+        assert result.update["pending_question"] == "장애 유형이 어떻게 되세요?"
+
+    async def test_interrupts_with_question_and_field(self):
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            return_value={"exist": True, "value": "지체장애", "re_ask": False},
+        ):
             with patch(
                 "agents.detail_interview.interrupt",
                 return_value="지체장애입니다",
@@ -62,15 +82,15 @@ class TestDetailInterviewNodeBasic:
 
         mock_interrupt.assert_called_once()
         call_args = mock_interrupt.call_args[0][0]
-        assert "question" in call_args
-        assert "missing_fields" in call_args
-        assert "disability_type" in call_args["missing_fields"]
+        assert call_args["question"] == "장애 유형이 어떻게 되세요?"
+        assert call_args["field"] == "disability_type"
 
-    async def test_messages_contain_ai_and_human(self, mock_llm):
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_DetailExtraction(disability_type="지체장애")
-        )
-        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+    async def test_messages_contain_ai_and_human(self):
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            return_value={"exist": True, "value": "지체장애", "re_ask": False},
+        ):
             with patch(
                 "agents.detail_interview.interrupt",
                 return_value="지체장애입니다",
@@ -90,229 +110,218 @@ class TestDetailInterviewNodeBasic:
 
 
 class TestDetailInterviewNodeExtraction:
-    async def test_extracted_fields_removed_from_missing(self, mock_llm):
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_DetailExtraction(
-                disability_type="지체장애", housing_type="자가"
-            )
-        )
-        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
-            with patch(
-                "agents.detail_interview.interrupt", return_value="지체장애, 자가"
-            ):
+    async def test_extracted_field_removed_from_missing(self):
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            return_value={"exist": True, "value": "지체장애", "re_ask": False},
+        ):
+            with patch("agents.detail_interview.interrupt", return_value="지체장애"):
                 state = _base_state(
-                    detail_missing_fields=[
-                        "disability_type",
-                        "housing_type",
-                        "is_veteran",
-                    ],
-                    pending_question="장애 유형과 주거 형태를 알려주세요.",
+                    detail_missing_fields=["disability_type", "housing_type"],
+                    pending_question="장애 유형이 어떻게 되세요?",
                 )
                 result = await detail_interview_node(state)
 
         assert "disability_type" not in result["detail_missing_fields"]
-        assert "housing_type" not in result["detail_missing_fields"]
-        assert "is_veteran" in result["detail_missing_fields"]
+        assert "housing_type" in result["detail_missing_fields"]
 
-    async def test_profile_updated_with_extracted_fields(self, mock_llm):
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_DetailExtraction(
-                disability_type="지체장애", housing_type="자가"
-            )
-        )
-        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
-            with patch(
-                "agents.detail_interview.interrupt", return_value="지체장애, 자가"
-            ):
+    async def test_profile_updated_with_extracted_field(self):
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            return_value={"exist": True, "value": "지체장애", "re_ask": False},
+        ):
+            with patch("agents.detail_interview.interrupt", return_value="지체장애"):
                 state = _base_state(
-                    detail_missing_fields=["disability_type", "housing_type"],
-                    pending_question="장애 유형과 주거 형태를 알려주세요.",
+                    detail_missing_fields=["disability_type"],
+                    pending_question="장애 유형이 어떻게 되세요?",
                 )
                 result = await detail_interview_node(state)
 
-        profile = result["user_profile"]
-        assert profile.disability_type == "지체장애"
-        assert profile.housing_type == "자가"
+        assert result["user_profile"].disability_type == "지체장애"
+
+    async def test_detail_current_field_cleared_on_success(self):
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            return_value={"exist": True, "value": "자가", "re_ask": False},
+        ):
+            with patch("agents.detail_interview.interrupt", return_value="자가입니다"):
+                state = _base_state(
+                    detail_missing_fields=["housing_type"],
+                    detail_current_field="housing_type",
+                    pending_question="주거 형태가 어떻게 되세요?",
+                )
+                result = await detail_interview_node(state)
+
+        assert result["detail_current_field"] is None
+
+    async def test_reask_sets_detail_current_field(self):
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            return_value={"exist": False, "value": None, "re_ask": True},
+        ):
+            with patch(
+                "agents.detail_interview.interrupt", return_value="잘 모르겠어요"
+            ):
+                state = _base_state(
+                    detail_missing_fields=["disability_type"],
+                    pending_question="장애 유형이 어떻게 되세요?",
+                )
+                result = await detail_interview_node(state)
+
+        assert result["detail_current_field"] == "disability_type"
+        assert result["pending_question"] is None
 
 
 class TestExtraFieldsHandling:
-    async def test_extra_field_stored_in_extra_fields(self, mock_llm):
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_DetailExtraction(extra_fields={"참전유공자": True})
-        )
-        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+    async def test_extra_field_stored_in_extra_fields(self):
+        extra_schemas = [
+            {"key": "참전유공자", "label": "국가보훈 대상 여부", "type": "bool"}
+        ]
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            return_value={"exist": True, "value": True, "re_ask": False},
+        ):
             with patch(
-                "agents.detail_interview.interrupt",
-                return_value="참전용사입니다",
+                "agents.detail_interview.interrupt", return_value="참전용사입니다"
             ):
                 state = _base_state(
                     detail_missing_fields=["extra:참전유공자"],
+                    extra_field_schemas=extra_schemas,
                     pending_question="국가보훈 대상이신가요?",
                 )
                 result = await detail_interview_node(state)
 
         assert result["user_profile"].extra_fields.get("참전유공자") is True
 
-    async def test_extra_field_removed_from_missing_after_extraction(self, mock_llm):
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_DetailExtraction(extra_fields={"참전유공자": True})
-        )
-        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+    async def test_extra_field_removed_from_missing_after_extraction(self):
+        extra_schemas = [
+            {"key": "참전유공자", "label": "국가보훈 대상 여부", "type": "bool"}
+        ]
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            return_value={"exist": True, "value": True, "re_ask": False},
+        ):
             with patch(
-                "agents.detail_interview.interrupt",
-                return_value="참전용사입니다",
+                "agents.detail_interview.interrupt", return_value="참전용사입니다"
             ):
                 state = _base_state(
                     detail_missing_fields=["extra:참전유공자"],
+                    extra_field_schemas=extra_schemas,
                     pending_question="국가보훈 대상이신가요?",
                 )
                 result = await detail_interview_node(state)
 
         assert "extra:참전유공자" not in result["detail_missing_fields"]
 
-    async def test_extra_field_remains_in_missing_when_not_extracted(self, mock_llm):
-        mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-            return_value=_DetailExtraction()
-        )
-        with patch("agents.detail_interview.get_llm", return_value=mock_llm):
+    async def test_extra_field_remains_when_not_extracted(self):
+        extra_schemas = [
+            {"key": "참전유공자", "label": "국가보훈 대상 여부", "type": "bool"}
+        ]
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            return_value={"exist": False, "value": None, "re_ask": True},
+        ):
             with patch("agents.detail_interview.interrupt", return_value="모름"):
                 state = _base_state(
                     detail_missing_fields=["extra:참전유공자"],
+                    extra_field_schemas=extra_schemas,
                     pending_question="국가보훈 대상이신가요?",
                 )
                 result = await detail_interview_node(state)
 
         assert "extra:참전유공자" in result["detail_missing_fields"]
 
-    async def test_existing_extra_fields_preserved_on_update(self):
+    async def test_unknown_extra_field_skipped(self):
+        state = _base_state(
+            detail_missing_fields=["extra:unknown_field"],
+            extra_field_schemas=[],
+        )
+        result = await detail_interview_node(state)
+        assert "extra:unknown_field" not in result["detail_missing_fields"]
+
+    def test_existing_extra_fields_preserved_on_update(self):
         profile = UserProfile(extra_fields={"기존키": "기존값"})
-        missing = ["extra:새키"]
-
-        with patch("agents.detail_interview.get_llm") as mock_get_llm:
-            mock_llm = MagicMock()
-            mock_llm.with_structured_output.return_value.ainvoke = AsyncMock(
-                return_value=_DetailExtraction(extra_fields={"새키": "새값"})
-            )
-            mock_get_llm.return_value = mock_llm
-
-            new_profile, _, _ = await _extract_profile(profile, missing, "새값", [])
-
+        new_profile = _apply_extracted_value(profile, "extra:새키", "새값")
         assert new_profile.extra_fields["기존키"] == "기존값"
         assert new_profile.extra_fields["새키"] == "새값"
 
 
-class TestStructuredOutputRetry:
-    async def test_all_fields_remain_on_max_retry_failure(self):
+class TestChildrenAgesParsing:
+    def test_children_ages_parsed_from_string(self):
         profile = UserProfile()
-        missing = ["disability_type", "housing_type"]
+        new_profile = _apply_extracted_value(profile, "children_ages", "5 8 12")
+        assert new_profile.children_ages == [5, 8, 12]
 
-        with patch("agents.detail_interview.get_llm") as mock_get_llm:
-            mock_llm = MagicMock()
-            mock_extractor = AsyncMock()
-            mock_extractor.ainvoke = AsyncMock(side_effect=Exception("파싱 실패"))
-            mock_llm.with_structured_output.return_value = mock_extractor
-            mock_get_llm.return_value = mock_llm
-
-            new_profile, new_missing, failed = await _extract_profile(
-                profile, missing, "내 답변", []
-            )
-
-        assert new_profile == profile
-        assert new_missing == missing
-        assert failed is True
-
-    async def test_retries_exactly_max_retry_plus_one_times(self):
+    def test_children_ages_parsed_with_comma(self):
         profile = UserProfile()
+        new_profile = _apply_extracted_value(profile, "children_ages", "3, 7")
+        assert new_profile.children_ages == [3, 7]
 
-        with patch("agents.detail_interview.get_llm") as mock_get_llm:
-            mock_llm = MagicMock()
-            mock_extractor = AsyncMock()
-            mock_extractor.ainvoke = AsyncMock(side_effect=Exception("파싱 실패"))
-            mock_llm.with_structured_output.return_value = mock_extractor
-            mock_get_llm.return_value = mock_llm
-
-            await _extract_profile(profile, ["disability_type"], "내 답변", [])
-
-            assert mock_extractor.ainvoke.call_count == 3  # 1 + _MAX_RETRY(2)
-
-    async def test_succeeds_on_second_attempt(self):
+    def test_children_ages_non_digit_ignored(self):
         profile = UserProfile()
-        missing = ["housing_type"]
+        new_profile = _apply_extracted_value(profile, "children_ages", "5살, 8살")
+        assert new_profile.children_ages == [5, 8]
 
-        with patch("agents.detail_interview.get_llm") as mock_get_llm:
-            mock_llm = MagicMock()
-            mock_extractor = AsyncMock()
-            mock_extractor.ainvoke = AsyncMock(
-                side_effect=[
-                    Exception("1차 실패"),
-                    _DetailExtraction(housing_type="전세"),
-                ]
+
+class TestGetFieldInfo:
+    def test_standard_field_returns_info(self):
+        info = _get_field_info("disability_type", [])
+        assert info is not None
+        assert info["key"] == "disability_type"
+
+    def test_unknown_field_returns_none(self):
+        info = _get_field_info("unknown_field", [])
+        assert info is None
+
+    def test_extra_field_found_in_schemas(self):
+        schemas = [{"key": "my_key", "label": "내 필드", "type": "bool"}]
+        info = _get_field_info("extra:my_key", schemas)
+        assert info is not None
+        assert info["key"] == "my_key"
+
+    def test_extra_field_not_in_schemas_returns_none(self):
+        info = _get_field_info("extra:missing_key", [])
+        assert info is None
+
+
+class TestErrorHandling:
+    async def test_ask_question_error_returns_error_message(self):
+        with patch(
+            "agents.detail_interview.hwnv_client.ask_detail_question",
+            new_callable=AsyncMock,
+            side_effect=Exception("연결 실패"),
+        ):
+            state = _base_state(
+                detail_missing_fields=["disability_type"],
+                pending_question=None,
             )
-            mock_llm.with_structured_output.return_value = mock_extractor
-            mock_get_llm.return_value = mock_llm
+            result = await detail_interview_node(state)
 
-            new_profile, new_missing, failed = await _extract_profile(
-                profile, missing, "전세입니다", []
-            )
+        msgs = result.get("messages", [])
+        assert any(isinstance(m, AIMessage) for m in msgs)
 
-        assert new_profile.housing_type == "전세"
-        assert "housing_type" not in new_missing
-        assert failed is False
+    async def test_extract_value_error_keeps_reask_state(self):
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            side_effect=Exception("파싱 실패"),
+        ):
+            with patch(
+                "agents.detail_interview.interrupt", return_value="지체장애입니다"
+            ):
+                state = _base_state(
+                    detail_missing_fields=["disability_type"],
+                    pending_question="장애 유형이 어떻게 되세요?",
+                )
+                result = await detail_interview_node(state)
 
-
-class TestGenerateQuestion:
-    @patch("agents.detail_interview.load_prompt", return_value="system prompt")
-    @patch("agents.detail_interview.get_llm")
-    async def test_returns_llm_content(self, mock_get_llm, mock_load_prompt, mock_llm):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.ainvoke = AsyncMock(
-            return_value=MagicMock(content="장애 유형이 어떻게 되세요?")
-        )
-        selected = WelfareCandidate(
-            serv_id="SVC001", serv_nm="장애인 활동지원", serv_dgst="..."
-        )
-
-        question = await _generate_question(
-            UserProfile(), ["disability_type"], selected, []
-        )
-
-        assert question == "장애 유형이 어떻게 되세요?"
-
-    @patch("agents.detail_interview.load_prompt", return_value="system prompt")
-    @patch("agents.detail_interview.get_llm")
-    async def test_history_included_in_messages(
-        self, mock_get_llm, mock_load_prompt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="질문"))
-        selected = WelfareCandidate(
-            serv_id="SVC001", serv_nm="장애인 활동지원", serv_dgst="..."
-        )
-
-        history = [HumanMessage(content="안녕하세요"), AIMessage(content="안녕하세요!")]
-        await _generate_question(UserProfile(), ["disability_type"], selected, history)
-
-        call_messages = mock_llm.ainvoke.call_args[0][0]
-        assert any(m.content == "안녕하세요" for m in call_messages)
-
-    @patch("agents.detail_interview.load_prompt", return_value="system prompt")
-    @patch("agents.detail_interview.get_llm")
-    async def test_service_context_included_in_instruction(
-        self, mock_get_llm, mock_load_prompt, mock_llm
-    ):
-        mock_get_llm.return_value = mock_llm
-        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="질문"))
-        selected = WelfareCandidate(
-            serv_id="SVC001",
-            serv_nm="장애인 활동지원",
-            serv_dgst="장애인 자립 지원 서비스",
-        )
-
-        await _generate_question(UserProfile(), ["disability_type"], selected, [])
-
-        call_messages = mock_llm.ainvoke.call_args[0][0]
-        last_human = next(
-            m for m in reversed(call_messages) if isinstance(m, HumanMessage)
-        )
-        assert "장애인 활동지원" in last_human.content
-        assert "장애인 자립 지원 서비스" in last_human.content
+        assert result["detail_current_field"] == "disability_type"
+        assert result["pending_question"] is None
+        assert "disability_type" in result["detail_missing_fields"]

--- a/tests/test_detail_interview.py
+++ b/tests/test_detail_interview.py
@@ -325,3 +325,21 @@ class TestErrorHandling:
         assert result["detail_current_field"] == "disability_type"
         assert result["pending_question"] is None
         assert "disability_type" in result["detail_missing_fields"]
+
+    async def test_exist_false_reask_false_skips_field(self):
+        with patch(
+            "agents.detail_interview.hwnv_client.extract_detail_value",
+            new_callable=AsyncMock,
+            return_value={"exist": False, "value": None, "re_ask": False},
+        ):
+            with patch("agents.detail_interview.interrupt", return_value="없습니다"):
+                state = _base_state(
+                    detail_missing_fields=["disability_type", "housing_type"],
+                    pending_question="장애 유형이 어떻게 되세요?",
+                )
+                result = await detail_interview_node(state)
+
+        assert "disability_type" not in result["detail_missing_fields"]
+        assert "housing_type" in result["detail_missing_fields"]
+        assert result["detail_current_field"] is None
+        assert result["pending_question"] is None

--- a/tests/test_rag_detail.py
+++ b/tests/test_rag_detail.py
@@ -342,3 +342,25 @@ class TestClassifySchemas:
         regular, extra = _classify_schemas(schemas, profile)
         assert "is_veteran" in regular
         assert any(s["key"] == "custom_field" for s in extra)
+
+    def test_children_field_excluded_when_has_children_false(self):
+        profile = UserProfile(has_children=False)
+        schemas = [
+            {"key": "has_children_age", "label": "자녀 연령", "type": "int"},
+            {"key": "deposit_amount", "label": "보증금", "type": "int"},
+        ]
+        regular, extra = _classify_schemas(schemas, profile)
+        assert not any(s["key"] == "has_children_age" for s in extra)
+        assert any(s["key"] == "deposit_amount" for s in extra)
+
+    def test_children_field_included_when_has_children_true(self):
+        profile = UserProfile(has_children=True)
+        schema = {"key": "has_children_age", "label": "자녀 연령", "type": "int"}
+        regular, extra = _classify_schemas([schema], profile)
+        assert schema in extra
+
+    def test_children_field_excluded_by_label_keyword(self):
+        profile = UserProfile(has_children=False)
+        schema = {"key": "child_info", "label": "자녀 나이", "type": "string"}
+        regular, extra = _classify_schemas([schema], profile)
+        assert extra == []

--- a/tests/test_rag_detail.py
+++ b/tests/test_rag_detail.py
@@ -46,6 +46,11 @@ def _make_state(**kwargs) -> AgentState:
         "interview_current_field": None,
         "interview_last_question": "",
         "interview_last_answer": "",
+        "pending_question": None,
+        "detail_current_field": None,
+        "detail_last_question": "",
+        "detail_last_answer": "",
+        "extra_field_schemas": [],
     }
     defaults.update(kwargs)
     return defaults  # type: ignore[return-value]
@@ -218,6 +223,71 @@ class TestRagDetailNode:
 
         call_kwargs = mock_infer.call_args.kwargs
         assert call_kwargs["trgter_indvdl"] == []
+
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
+    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_extra_field_schemas_populated_when_extra_missing(
+        self, mock_get_detail, mock_infer, mock_extractor
+    ):
+        """Extra 필드 있으면 field_extractor 호출 → extra_field_schemas 저장."""
+        mock_get_detail.return_value = _DUMMY_DETAIL
+        mock_infer.return_value = ["extra:deposit_amount"]
+        mock_extractor.return_value = [
+            {
+                "key": "deposit_amount",
+                "label": "보증금",
+                "type": "int",
+                "question_hint": "보증금을 물어보세요",
+            }
+        ]
+
+        result = await rag_detail_node(_make_state())
+
+        mock_extractor.assert_called_once()
+        assert result["extra_field_schemas"] == [
+            {
+                "key": "deposit_amount",
+                "label": "보증금",
+                "type": "int",
+                "question_hint": "보증금을 물어보세요",
+            }
+        ]
+
+    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_extra_field_schemas_empty_when_no_extra_missing(
+        self, mock_get_detail, mock_infer
+    ):
+        """Extra 필드 없으면 field_extractor 미호출 → extra_field_schemas 빈 리스트."""
+        mock_get_detail.return_value = _DUMMY_DETAIL
+        mock_infer.return_value = ["housing_type"]
+
+        result = await rag_detail_node(_make_state())
+
+        assert result["extra_field_schemas"] == []
+
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
+    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_extra_field_schemas_empty_on_extractor_error(
+        self, mock_get_detail, mock_infer, mock_extractor
+    ):
+        """field_extractor 실패 → extra_field_schemas 빈 리스트, 노드는 계속 진행."""
+        mock_get_detail.return_value = _DUMMY_DETAIL
+        mock_infer.return_value = ["extra:deposit_amount"]
+        mock_extractor.side_effect = Exception("hwnv 오류")
+
+        result = await rag_detail_node(_make_state())
+
+        assert result["extra_field_schemas"] == []
+        assert result["detail_missing_fields"] == ["extra:deposit_amount"]
 
 
 class TestInferMissingFields:

--- a/tests/test_rag_detail.py
+++ b/tests/test_rag_detail.py
@@ -1,11 +1,10 @@
 """RAG 상세 조회 노드 테스트."""
 
-import os
 from unittest.mock import AsyncMock, patch
 
 from langchain_core.messages import AIMessage
 
-from agents.rag_detail import _infer_missing_fields, _RequiredFields, rag_detail_node
+from agents.rag_detail import _classify_schemas, rag_detail_node
 from graph.state import (
     AgentState,
     EmploymentStatus,
@@ -69,13 +68,16 @@ _DUMMY_DETAIL = {
 
 
 class TestRagDetailNode:
-    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
     async def test_updates_selected_service_on_success(
-        self, mock_get_detail, mock_infer
+        self, mock_get_detail, mock_extractor
     ):
         mock_get_detail.return_value = _DUMMY_DETAIL
-        mock_infer.return_value = []
+        mock_extractor.return_value = []
 
         result = await rag_detail_node(_make_state())
 
@@ -88,13 +90,16 @@ class TestRagDetailNode:
         )
         assert updated.application_url == "https://www.bokjiro.go.kr"
 
-    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
     async def test_preserves_existing_fields_on_success(
-        self, mock_get_detail, mock_infer
+        self, mock_get_detail, mock_extractor
     ):
         mock_get_detail.return_value = _DUMMY_DETAIL
-        mock_infer.return_value = []
+        mock_extractor.return_value = []
 
         result = await rag_detail_node(_make_state())
 
@@ -143,16 +148,19 @@ class TestRagDetailNode:
 
         assert result["detail_missing_fields"] == []
 
-    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
     async def test_missing_optional_fields_default_to_empty(
-        self, mock_get_detail, mock_infer
+        self, mock_get_detail, mock_extractor
     ):
         mock_get_detail.return_value = {
             "serv_id": "WLF-001",
             "serv_nm": "기초생활수급자 생계급여",
         }
-        mock_infer.return_value = []
+        mock_extractor.return_value = []
 
         result = await rag_detail_node(_make_state())
 
@@ -162,41 +170,109 @@ class TestRagDetailNode:
         assert updated.application_url is None
         assert updated.detail_fetched is True
 
-    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
-    async def test_sets_detail_missing_fields_from_llm(
-        self, mock_get_detail, mock_infer
+    async def test_standard_fields_in_detail_missing_fields(
+        self, mock_get_detail, mock_extractor
     ):
         mock_get_detail.return_value = _DUMMY_DETAIL
-        mock_infer.return_value = ["housing_type", "is_veteran"]
+        mock_extractor.return_value = [
+            {
+                "key": "housing_type",
+                "label": "주거 형태",
+                "type": "enum",
+                "enum_values": ["자가", "전세", "월세"],
+            },
+            {"key": "is_veteran", "label": "국가보훈 대상 여부", "type": "bool"},
+        ]
 
         result = await rag_detail_node(_make_state())
 
-        assert result["detail_missing_fields"] == ["housing_type", "is_veteran"]
+        assert "housing_type" in result["detail_missing_fields"]
+        assert "is_veteran" in result["detail_missing_fields"]
 
-    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
-    async def test_passes_eligibility_fields_to_infer(
-        self, mock_get_detail, mock_infer
+    async def test_extra_fields_prefixed_in_detail_missing_fields(
+        self, mock_get_detail, mock_extractor
     ):
         mock_get_detail.return_value = _DUMMY_DETAIL
-        mock_infer.return_value = []
+        mock_extractor.return_value = [
+            {"key": "deposit_amount", "label": "보증금", "type": "int"},
+        ]
+
+        result = await rag_detail_node(_make_state())
+
+        assert "extra:deposit_amount" in result["detail_missing_fields"]
+
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_extra_field_schemas_stored_in_state(
+        self, mock_get_detail, mock_extractor
+    ):
+        schema = {"key": "deposit_amount", "label": "보증금", "type": "int"}
+        mock_get_detail.return_value = _DUMMY_DETAIL
+        mock_extractor.return_value = [schema]
+
+        result = await rag_detail_node(_make_state())
+
+        assert schema in result["extra_field_schemas"]
+
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_passes_service_info_to_field_extractor(
+        self, mock_get_detail, mock_extractor
+    ):
+        mock_get_detail.return_value = _DUMMY_DETAIL
+        mock_extractor.return_value = []
 
         await rag_detail_node(_make_state())
 
-        call_kwargs = mock_infer.call_args.kwargs
-        assert call_kwargs["tgtr_dtl_cn"] == _DUMMY_DETAIL["tgtr_dtl_cn"]
-        assert call_kwargs["slct_crit_cn"] == _DUMMY_DETAIL["slct_crit_cn"]
-        assert call_kwargs["trgter_indvdl"] == _DUMMY_DETAIL["trgter_indvdl"]
+        call_args = mock_extractor.call_args[0][0]
+        assert call_args["serv_nm"] == _DUMMY_DETAIL["serv_nm"]
+        assert call_args["tgtr_dtl_cn"] == _DUMMY_DETAIL["tgtr_dtl_cn"]
+        assert call_args["slct_crit_cn"] == _DUMMY_DETAIL["slct_crit_cn"]
+        assert call_args["trgter_indvdl"] == _DUMMY_DETAIL["trgter_indvdl"]
 
-    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
+    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
+    async def test_field_extractor_error_returns_empty_missing(
+        self, mock_get_detail, mock_extractor
+    ):
+        mock_get_detail.return_value = _DUMMY_DETAIL
+        mock_extractor.side_effect = Exception("hwnv 오류")
+
+        result = await rag_detail_node(_make_state())
+
+        assert result["detail_missing_fields"] == []
+        assert result["extra_field_schemas"] == []
+
+    @patch(
+        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
     async def test_first_attempt_fails_second_succeeds(
-        self, mock_get_detail, mock_infer
+        self, mock_get_detail, mock_extractor
     ):
         """RAG 첫 시도 실패 → 두 번째 성공 → 정상 처리."""
         mock_get_detail.side_effect = [Exception("일시 오류"), _DUMMY_DETAIL]
-        mock_infer.return_value = []
+        mock_extractor.return_value = []
 
         result = await rag_detail_node(_make_state())
 
@@ -207,298 +283,62 @@ class TestRagDetailNode:
             "신분증",
         ]
 
-    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
-    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
-    async def test_missing_trgter_indvdl_passes_empty_list_to_infer(
-        self, mock_get_detail, mock_infer
-    ):
-        """trgter_indvdl 없는 응답 → 빈 리스트로 _infer_missing_fields 호출."""
-        detail_without_trgter = {
-            k: v for k, v in _DUMMY_DETAIL.items() if k != "trgter_indvdl"
-        }
-        mock_get_detail.return_value = detail_without_trgter
-        mock_infer.return_value = []
 
-        await rag_detail_node(_make_state())
+class TestClassifySchemas:
+    """_classify_schemas 단위 테스트."""
 
-        call_kwargs = mock_infer.call_args.kwargs
-        assert call_kwargs["trgter_indvdl"] == []
+    def test_standard_field_goes_to_regular_missing(self):
+        profile = UserProfile(disability=False)
+        schemas = [{"key": "housing_type", "label": "주거 형태", "type": "enum"}]
+        regular, extra = _classify_schemas(schemas, profile)
+        assert "housing_type" in regular
+        assert extra == []
 
-    @patch(
-        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
-        new_callable=AsyncMock,
-    )
-    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
-    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
-    async def test_extra_field_schemas_populated_when_extra_missing(
-        self, mock_get_detail, mock_infer, mock_extractor
-    ):
-        """Extra 필드 있으면 field_extractor 호출 → extra_field_schemas 저장."""
-        mock_get_detail.return_value = _DUMMY_DETAIL
-        mock_infer.return_value = ["extra:deposit_amount"]
-        mock_extractor.return_value = [
-            {
-                "key": "deposit_amount",
-                "label": "보증금",
-                "type": "int",
-                "question_hint": "보증금을 물어보세요",
-            }
+    def test_unknown_field_goes_to_extra_schemas(self):
+        profile = UserProfile(disability=False)
+        schema = {"key": "deposit_amount", "label": "보증금", "type": "int"}
+        regular, extra = _classify_schemas([schema], profile)
+        assert regular == []
+        assert schema in extra
+
+    def test_already_filled_standard_field_skipped(self):
+        profile = UserProfile(disability=False, housing_type="자가")
+        schemas = [{"key": "housing_type", "label": "주거 형태", "type": "enum"}]
+        regular, extra = _classify_schemas(schemas, profile)
+        assert "housing_type" not in regular
+
+    def test_already_filled_extra_field_skipped(self):
+        profile = UserProfile(disability=False, extra_fields={"deposit": 5000})
+        schemas = [{"key": "deposit", "label": "보증금", "type": "int"}]
+        regular, extra = _classify_schemas(schemas, profile)
+        assert extra == []
+
+    def test_disability_fields_excluded_when_disability_false(self):
+        profile = UserProfile(disability=False)
+        schemas = [
+            {"key": "disability_type", "label": "장애 유형", "type": "string"},
+            {"key": "disability_grade", "label": "장애 등급", "type": "string"},
+            {"key": "housing_type", "label": "주거 형태", "type": "enum"},
         ]
+        regular, _ = _classify_schemas(schemas, profile)
+        assert "disability_type" not in regular
+        assert "disability_grade" not in regular
+        assert "housing_type" in regular
 
-        result = await rag_detail_node(_make_state())
-
-        mock_extractor.assert_called_once()
-        assert result["extra_field_schemas"] == [
-            {
-                "key": "deposit_amount",
-                "label": "보증금",
-                "type": "int",
-                "question_hint": "보증금을 물어보세요",
-            }
+    def test_disability_fields_included_when_disability_true(self):
+        profile = UserProfile(disability=True)
+        schemas = [
+            {"key": "disability_type", "label": "장애 유형", "type": "string"},
         ]
+        regular, _ = _classify_schemas(schemas, profile)
+        assert "disability_type" in regular
 
-    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
-    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
-    async def test_extra_field_schemas_empty_when_no_extra_missing(
-        self, mock_get_detail, mock_infer
-    ):
-        """Extra 필드 없으면 field_extractor 미호출 → extra_field_schemas 빈 리스트."""
-        mock_get_detail.return_value = _DUMMY_DETAIL
-        mock_infer.return_value = ["housing_type"]
-
-        result = await rag_detail_node(_make_state())
-
-        assert result["extra_field_schemas"] == []
-
-    @patch(
-        "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
-        new_callable=AsyncMock,
-    )
-    @patch("agents.rag_detail._infer_missing_fields", new_callable=AsyncMock)
-    @patch("agents.rag_detail.rag_client.get_detail", new_callable=AsyncMock)
-    async def test_extra_field_schemas_empty_on_extractor_error(
-        self, mock_get_detail, mock_infer, mock_extractor
-    ):
-        """field_extractor 실패 → extra_field_schemas 빈 리스트, 노드는 계속 진행."""
-        mock_get_detail.return_value = _DUMMY_DETAIL
-        mock_infer.return_value = ["extra:deposit_amount"]
-        mock_extractor.side_effect = Exception("hwnv 오류")
-
-        result = await rag_detail_node(_make_state())
-
-        assert result["extra_field_schemas"] == []
-        assert result["detail_missing_fields"] == ["extra:deposit_amount"]
-
-
-class TestInferMissingFields:
-    """_infer_missing_fields 단위 테스트 — get_llm만 mock."""
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_returns_fields_not_in_profile(self, mock_get_llm):
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(
-            return_value=_RequiredFields(
-                regular_fields=["housing_type", "is_veteran"], extra_fields=[]
-            )
-        )
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
-        result = await _infer_missing_fields(
-            profile, "대상자", "선정기준", ["저소득층"]
-        )
-
-        assert "housing_type" in result
-        assert "is_veteran" in result
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_skips_already_filled_fields(self, mock_get_llm):
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(
-            return_value=_RequiredFields(
-                regular_fields=["housing_type", "is_veteran"], extra_fields=[]
-            )
-        )
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(
-            age=65,
-            income_level=IncomeLevel.BASIC,
-            disability=False,
-            housing_type="아파트",  # already filled
-        )
-        result = await _infer_missing_fields(
-            profile, "대상자", "선정기준", ["저소득층"]
-        )
-
-        assert "housing_type" not in result
-        assert "is_veteran" in result
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_skips_invalid_field_names_not_in_stage2(self, mock_get_llm):
-        """LLM이 _STAGE_2_FIELDS에 없는 필드명 반환 → 제외."""
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(
-            return_value=_RequiredFields(
-                regular_fields=["invalid_field", "nonexistent_key", "housing_type"],
-                extra_fields=[],
-            )
-        )
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
-        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
-
-        assert "invalid_field" not in result
-        assert "nonexistent_key" not in result
-        assert "housing_type" in result
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_skips_extra_fields_already_in_profile(self, mock_get_llm):
-        """LLM이 profile.extra_fields에 이미 있는 키 반환 → 제외."""
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(
-            return_value=_RequiredFields(
-                regular_fields=[],
-                extra_fields=["deposit_amount", "existing_key"],
-            )
-        )
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(
-            age=65,
-            income_level=IncomeLevel.BASIC,
-            disability=False,
-            extra_fields={"existing_key": "some_value"},  # already in profile
-        )
-        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
-
-        assert "extra:deposit_amount" in result
-        assert "extra:existing_key" not in result
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_extra_fields_prefixed_correctly(self, mock_get_llm):
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(
-            return_value=_RequiredFields(
-                regular_fields=[], extra_fields=["deposit_amount"]
-            )
-        )
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
-        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
-
-        assert "extra:deposit_amount" in result
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_llm_failure_returns_empty_list(self, mock_get_llm):
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(side_effect=Exception("LLM error"))
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
-        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
-
-        assert result == []
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_llm_failure_retries_max_retry_plus_one_times(self, mock_get_llm):
-        """모든 시도 실패 → LLM_MAX_RETRY+1회 시도 후 빈 리스트 반환."""
-        max_retry = int(os.getenv("LLM_MAX_RETRY", "2"))
-
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(side_effect=Exception("LLM error"))
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
-        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
-
-        assert result == []
-        assert extractor.ainvoke.call_count == max_retry + 1
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_first_attempt_fails_second_succeeds(self, mock_get_llm):
-        """첫 시도 실패 후 두 번째에 성공 → 정상 반환."""
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(
-            side_effect=[
-                Exception("일시 오류"),
-                _RequiredFields(regular_fields=["is_veteran"], extra_fields=[]),
-            ]
-        )
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
-        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
-
-        assert "is_veteran" in result
-        assert extractor.ainvoke.call_count == 2
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_empty_eligibility_text_still_calls_llm(self, mock_get_llm):
-        """빈 eligibility 텍스트 입력 → LLM 호출은 하되 결과에 따라 반환."""
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(
-            return_value=_RequiredFields(regular_fields=[], extra_fields=[])
-        )
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
-        result = await _infer_missing_fields(profile, "", "", [])
-
-        assert extractor.ainvoke.call_count == 1
-        assert result == []
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_both_fields_empty_returns_empty_list(self, mock_get_llm):
-        """regular_fields와 extra_fields 모두 비어있는 반환 → 빈 리스트."""
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(
-            return_value=_RequiredFields(regular_fields=[], extra_fields=[])
-        )
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
-        result = await _infer_missing_fields(
-            profile, "대상자", "선정기준", ["저소득층"]
-        )
-
-        assert result == []
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_disability_fields_excluded_when_disability_false(self, mock_get_llm):
-        """disability=False이면 disability_type·disability_grade는 반환에서 제외."""
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(
-            return_value=_RequiredFields(
-                regular_fields=["disability_type", "disability_grade", "housing_type"],
-                extra_fields=[],
-            )
-        )
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=False)
-        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
-
-        assert "disability_type" not in result
-        assert "disability_grade" not in result
-        assert "housing_type" in result
-
-    @patch("agents.rag_detail.get_llm")
-    async def test_disability_fields_included_when_disability_true(self, mock_get_llm):
-        """disability=True이면 disability_type·disability_grade가 포함될 수 있다."""
-        extractor = AsyncMock()
-        extractor.ainvoke = AsyncMock(
-            return_value=_RequiredFields(
-                regular_fields=["disability_type", "disability_grade"],
-                extra_fields=[],
-            )
-        )
-        mock_get_llm.return_value.with_structured_output.return_value = extractor
-
-        profile = UserProfile(age=65, income_level=IncomeLevel.BASIC, disability=True)
-        result = await _infer_missing_fields(profile, "대상자", "선정기준", [])
-
-        assert "disability_type" in result
-        assert "disability_grade" in result
+    def test_mixed_standard_and_extra_fields(self):
+        profile = UserProfile(disability=False)
+        schemas = [
+            {"key": "is_veteran", "label": "보훈 대상", "type": "bool"},
+            {"key": "custom_field", "label": "커스텀", "type": "string"},
+        ]
+        regular, extra = _classify_schemas(schemas, profile)
+        assert "is_veteran" in regular
+        assert any(s["key"] == "custom_field" for s in extra)

--- a/tools/hwnv_client.py
+++ b/tools/hwnv_client.py
@@ -92,3 +92,123 @@ async def extract_value(
             if content.startswith("json"):
                 content = content[4:]
         return json.loads(content.strip())
+
+
+def _parse_json_content(content: str) -> dict | list:
+    """마크다운 펜스를 제거하고 JSON을 파싱합니다."""
+    if content.startswith("```"):
+        content = content.split("```", 2)[1]
+        if content.startswith("json"):
+            content = content[4:]
+    return json.loads(content.strip())
+
+
+async def ask_detail_question(
+    field_info: dict,
+    re_ask: bool,
+    pre_assistant_message: str = "",
+    pre_user_message: str = "",
+) -> str:
+    """detail_asker 프로필로 2단계 추가 필드 질문을 생성합니다.
+
+    Args:
+        field_info: {key, label, type, enum_values?, question_hint?}
+        re_ask: 재질문 여부
+        pre_assistant_message: 직전 봇 발화
+        pre_user_message: 직전 사용자 발화
+
+    Returns:
+        생성된 질문 문자열
+    """
+    payload: dict = {"field": field_info, "re_ask": re_ask}
+    if pre_assistant_message:
+        payload["pre_assistant_message"] = pre_assistant_message
+        payload["pre_user_message"] = pre_user_message
+
+    async with httpx.AsyncClient(base_url=_BASE_URL, timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "detail_asker",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": json.dumps(payload, ensure_ascii=False),
+                    }
+                ],
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"]
+
+
+async def extract_detail_value(
+    field_info: dict,
+    assistant_message: str,
+    user_message: str,
+) -> dict:
+    """detail_interviewer 프로필로 사용자 답변에서 추가 필드 값을 추출합니다.
+
+    Args:
+        field_info: {key, label, type, enum_values?}
+        assistant_message: 봇이 했던 질문
+        user_message: 사용자 답변
+
+    Returns:
+        {"exist": bool, "value": any | None, "re_ask": bool, "reasoning": str}
+    """
+    payload = {
+        "field": field_info,
+        "assistant_message": assistant_message,
+        "user_message": user_message,
+    }
+
+    async with httpx.AsyncClient(base_url=_BASE_URL, timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "detail_interviewer",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": json.dumps(payload, ensure_ascii=False),
+                    }
+                ],
+                "response_format": {"type": "json_object"},
+            },
+        )
+        resp.raise_for_status()
+        content = resp.json()["choices"][0]["message"]["content"]
+        return _parse_json_content(content)
+
+
+async def extract_extra_field_schemas(service_info: dict) -> list[dict]:
+    """field_extractor 프로필로 서비스 추가 필드 스키마를 생성합니다.
+
+    Args:
+        service_info: {serv_nm, tgtr_dtl_cn, slct_crit_cn, trgter_indvdl}
+
+    Returns:
+        [{"key", "label", "type", "enum_values"?, "question_hint", "reason"}]
+        실패 시 빈 리스트
+    """
+    payload = {"service": service_info}
+
+    async with httpx.AsyncClient(base_url=_BASE_URL, timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "field_extractor",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": json.dumps(payload, ensure_ascii=False),
+                    }
+                ],
+                "response_format": {"type": "json_object"},
+            },
+        )
+        resp.raise_for_status()
+        content = resp.json()["choices"][0]["message"]["content"]
+        result = _parse_json_content(content)
+        return result.get("extra_fields", [])


### PR DESCRIPTION
## 📝 PR 설명

  - 2단계 인터뷰를 hwnv LLM 서버 기반으로 전환하고, 실 테스트에서 발견된 버그 2건을 수정합니다.

  ## 🛠️ 작업 상세 내용

  - `tools/hwnv_client.py`: `ask_detail_question`, `extract_detail_value`, `extract_extra_field_schemas` 추가
  - `graph/state.py`: 2단계 인터뷰 tracking용 필드 4개 추가
  - `agents/detail_interview.py`: Groq LLM 제거 → hwnv `detail_asker`/`detail_interviewer` 기반 필드별 처리로 재작성.
  1단계와 동일한 `pending_question` 캐시 패턴 적용
  - `agents/rag_detail.py`: Groq `_infer_missing_fields` 제거 → hwnv `field_extractor` 단일 호출 + `_classify_schemas`로
   표준/extra 필드 분류
  - 버그 수정 1: `detail_interviewer`가 `{exist: false, re_ask: false}` 반환 시 필드 스킵 없이 무한 재질문되던 문제 수정
  - 버그 수정 2: `has_children=False`임에도 자녀 연령 관련 extra 필드를 2단계에서 재질문하던 문제 수정

  ## 🧪 테스트 여부 및 확인 내용

  - 단위 테스트 138개 전체 통과 (`uv run pytest tests/ -v`)
  - 실 서버 동작 확인: 1단계 → 서비스 선택 → 2단계 인터뷰 → 최종 보고서 정상 완료

  ## 💬 기타 / 참고사항

  - `field_extractor`가 나이·소득 등 1단계 수집 정보와 중복되는 필드를 생성하는 문제가 남아 있음. 해결을 위해
  `field_extractor`에 `UserProfile` 컨텍스트를 전달하도록 변경이 필요하며, llm/ 담당자에게 프롬프트 수정 요청 예정

  ## 🔗 연관 이슈

  - Closes #59 