### PR TITLE
feat: eligibility_reason 생성을 elig_reasoner(hwnv)로 전환

### DIFF
--- a/agents/rag_search.py
+++ b/agents/rag_search.py
@@ -5,9 +5,9 @@ import os
 
 from langchain_core.messages import AIMessage
 
+import tools.hwnv_client as hwnv_client
 import tools.rag_client as rag_client
 from graph.state import AgentState, UserProfile, WelfareCandidate
-from tools.llm import get_llm
 
 
 def _profile_to_dict(profile: UserProfile) -> dict:
@@ -32,24 +32,6 @@ def _profile_to_dict(profile: UserProfile) -> dict:
     if profile.has_children is not None:
         data["has_children"] = profile.has_children
     return data
-
-
-async def _generate_eligibility_reason(
-    llm, serv_nm: str, serv_dgst: str, profile: UserProfile
-) -> str:
-    """서비스 요약과 사용자 프로필을 기반으로 선정 이유를 생성."""
-    prompt = (
-        f"다음 복지 서비스가 이 사용자에게 적합한 이유를 한 문장으로 설명하세요.\n\n"
-        f"서비스명: {serv_nm}\n"
-        f"서비스 요약: {serv_dgst}\n"
-        f"사용자 정보: 나이 {profile.age}세, 지역 {profile.region}, "
-        f"소득수준 {profile.income_level}"
-    )
-    try:
-        response = await llm.ainvoke(prompt)
-        return response.content
-    except Exception:
-        return ""
 
 
 async def rag_search_node(state: AgentState) -> dict:
@@ -93,13 +75,13 @@ async def rag_search_node(state: AgentState) -> dict:
     # score 내림차순 정렬
     results.sort(key=lambda x: x.get("score", 0.0), reverse=True)
 
-    llm = get_llm()
-
     # 후보별 선정 이유를 병렬로 생성
     reasons = await asyncio.gather(
         *[
-            _generate_eligibility_reason(
-                llm, item["serv_nm"], item["serv_dgst"], profile
+            hwnv_client.generate_eligibility_reason(
+                serv_nm=item["serv_nm"],
+                serv_dgst=item["serv_dgst"],
+                user=_profile_to_dict(profile),
             )
             for item in results
         ]

--- a/tests/test_rag_search.py
+++ b/tests/test_rag_search.py
@@ -1,6 +1,6 @@
 """RAG 검색 노드 테스트."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from langchain_core.messages import AIMessage
 
@@ -115,13 +115,14 @@ class TestProfileToDict:
 
 
 class TestRagSearchNode:
-    @patch("agents.rag_search.get_llm")
+    @patch(
+        "agents.rag_search.hwnv_client.generate_eligibility_reason",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
-    async def test_returns_candidates_on_success(self, mock_search, mock_get_llm):
+    async def test_returns_candidates_on_success(self, mock_search, mock_reason):
         mock_search.return_value = _DUMMY_RAG_RESULTS
-        mock_llm = MagicMock()
-        mock_llm.invoke.return_value = MagicMock(content="해당 서비스 대상자입니다.")
-        mock_get_llm.return_value = mock_llm
+        mock_reason.return_value = "해당 서비스 대상자입니다."
 
         result = await rag_search_node(_make_state())
 
@@ -130,17 +131,18 @@ class TestRagSearchNode:
             isinstance(c, WelfareCandidate) for c in result["welfare_candidates"]
         )
 
-    @patch("agents.rag_search.get_llm")
+    @patch(
+        "agents.rag_search.hwnv_client.generate_eligibility_reason",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
-    async def test_priority_assigned_by_score_order(self, mock_search, mock_get_llm):
+    async def test_priority_assigned_by_score_order(self, mock_search, mock_reason):
         unsorted = [
             {**_DUMMY_RAG_RESULTS[1], "score": 0.80},
             {**_DUMMY_RAG_RESULTS[0], "score": 0.95},
         ]
         mock_search.return_value = unsorted
-        mock_llm = MagicMock()
-        mock_llm.invoke.return_value = MagicMock(content="")
-        mock_get_llm.return_value = mock_llm
+        mock_reason.return_value = ""
 
         result = await rag_search_node(_make_state())
 
@@ -150,13 +152,15 @@ class TestRagSearchNode:
         assert candidates[1].priority == 2
         assert candidates[1].score == 0.80
 
-    @patch("agents.rag_search.get_llm")
+    @patch(
+        "agents.rag_search.hwnv_client.generate_eligibility_reason",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
     async def test_empty_result_returns_no_candidates_with_message(
-        self, mock_search, mock_get_llm
+        self, mock_search, mock_reason
     ):
         mock_search.return_value = []
-        mock_get_llm.return_value = MagicMock()
 
         result = await rag_search_node(_make_state())
 
@@ -164,13 +168,15 @@ class TestRagSearchNode:
         assert isinstance(result["messages"][0], AIMessage)
         assert "찾지 못했습니다" in result["messages"][0].content
 
-    @patch("agents.rag_search.get_llm")
+    @patch(
+        "agents.rag_search.hwnv_client.generate_eligibility_reason",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
     async def test_network_error_retries_and_returns_error_message(
-        self, mock_search, mock_get_llm
+        self, mock_search, mock_reason
     ):
         mock_search.side_effect = Exception("Connection error")
-        mock_get_llm.return_value = MagicMock()
 
         result = await rag_search_node(_make_state())
 
@@ -179,19 +185,19 @@ class TestRagSearchNode:
         assert "연결 오류" in result["messages"][0].content
         assert mock_search.call_count == 2  # 1회 재시도 확인
 
-    @patch("agents.rag_search.get_llm")
+    @patch(
+        "agents.rag_search.hwnv_client.generate_eligibility_reason",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
     async def test_eligibility_reason_generated_per_candidate(
-        self, mock_search, mock_get_llm
+        self, mock_search, mock_reason
     ):
         mock_search.return_value = _DUMMY_RAG_RESULTS
-        mock_llm = MagicMock()
-        mock_llm.ainvoke = AsyncMock(
-            return_value=MagicMock(content="적합한 서비스입니다.")
-        )
-        mock_get_llm.return_value = mock_llm
+        mock_reason.return_value = "적합한 서비스입니다."
 
         result = await rag_search_node(_make_state())
 
+        assert mock_reason.call_count == len(_DUMMY_RAG_RESULTS)
         for candidate in result["welfare_candidates"]:
-            assert candidate.eligibility_reason != ""
+            assert candidate.eligibility_reason == "적합한 서비스입니다."

--- a/tools/hwnv_client.py
+++ b/tools/hwnv_client.py
@@ -212,3 +212,41 @@ async def extract_extra_field_schemas(service_info: dict) -> list[dict]:
         content = resp.json()["choices"][0]["message"]["content"]
         result = _parse_json_content(content)
         return result.get("extra_fields", [])
+
+
+async def generate_eligibility_reason(
+    serv_nm: str,
+    serv_dgst: str,
+    user: dict,
+) -> str:
+    """elig_reasoner 프로필로 서비스 선정 이유를 한 문장 생성합니다.
+
+    Returns:
+        선정 이유 문자열. 실패 시 빈 문자열.
+    """
+    payload = {
+        "user": user,
+        "service": {
+            "serv_nm": serv_nm,
+            "serv_dgst": serv_dgst,
+            "trgterIndvdlArray": "",
+        },
+    }
+    try:
+        async with httpx.AsyncClient(base_url=_BASE_URL, timeout=_TIMEOUT) as client:
+            resp = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "elig_reasoner",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": json.dumps(payload, ensure_ascii=False),
+                        }
+                    ],
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception:
+        return ""


### PR DESCRIPTION
  ## 📝 PR 설명

  - `rag_search`의 `eligibility_reason` 생성을 Groq에서 hwnv `elig_reasoner`로 전환

  ## 🛠️ 작업 상세 내용

  - `tools/hwnv_client.py`: `generate_eligibility_reason(serv_nm, serv_dgst, user)` 추가
    - `elig_reasoner` 프로필 호출, 실패 시 빈 문자열 반환
  - `agents/rag_search.py`: `get_llm()` import 및 `_generate_eligibility_reason()` 제거, hwnv 호출로 교체
  - `tests/test_rag_search.py`: `get_llm` mock → `hwnv_client.generate_eligibility_reason` AsyncMock으로 교체

  ## 🧪 테스트 여부 및 확인 내용

  - `uv run pytest tests/` — 142 passed (서버 연결 불필요한 테스트 기준)
  - 수동: hwnv 서버 실행 후 서비스 선택 화면에서 `eligibility_reason` 표시 확인 필요

  ## 💬 기타 / 참고사항

  - `trgterIndvdlArray`는 RAG 검색 응답에 없어 빈 문자열 전달 — llm 팀과 필요 시 협의

  ## 🔗 연관 이슈

  - Closes #61 