### PR TITLE
feat: RAG application_forms(서류 다운로드 링크) 수신 및 state 저장

### DIFF
--- a/agents/rag_detail.py
+++ b/agents/rag_detail.py
@@ -97,6 +97,7 @@ async def rag_detail_node(state: AgentState) -> dict:
             "required_documents": detail.get("required_documents", []),
             "application_method": detail.get("application_method", ""),
             "application_url": detail.get("application_url"),
+            "application_forms": detail.get("application_forms", []),
             "detail_fetched": True,
         }
     )

--- a/graph/state.py
+++ b/graph/state.py
@@ -88,6 +88,7 @@ class WelfareCandidate(BaseModel):
     required_documents: list[str] = []
     application_method: str = ""
     application_url: str | None = None
+    application_forms: list[dict] = []  # [{"title", "url", "file_type"}]
     detail_fetched: bool = False
 
 

--- a/tests/test_rag_detail.py
+++ b/tests/test_rag_detail.py
@@ -61,6 +61,13 @@ _DUMMY_DETAIL = {
     "required_documents": ["사회보장급여 신청서", "신분증"],
     "application_method": "읍면동 주민센터 방문 신청, 사회보장급여 신청서 제출",
     "application_url": "https://www.bokjiro.go.kr",
+    "application_forms": [
+        {
+            "title": "사회보장급여 신청서",
+            "url": "https://www.bokjiro.go.kr/form.hwp",
+            "file_type": "hwp",
+        },
+    ],
     "tgtr_dtl_cn": "기초생활수급자 중 생계급여 수급자",
     "slct_crit_cn": "소득인정액이 생계급여 선정기준 이하인 자",
     "trgter_indvdl": ["저소득층"],
@@ -89,6 +96,7 @@ class TestRagDetailNode:
             == "읍면동 주민센터 방문 신청, 사회보장급여 신청서 제출"
         )
         assert updated.application_url == "https://www.bokjiro.go.kr"
+        assert updated.application_forms == _DUMMY_DETAIL["application_forms"]
 
     @patch(
         "agents.rag_detail.hwnv_client.extract_extra_field_schemas",
@@ -168,6 +176,7 @@ class TestRagDetailNode:
         assert updated.required_documents == []
         assert updated.application_method == ""
         assert updated.application_url is None
+        assert updated.application_forms == []
         assert updated.detail_fetched is True
 
     @patch(


### PR DESCRIPTION
## 📝 PR 설명

- RAG 상세 조회 응답의 `application_forms`(서류 다운로드 링크 목록)를 AI state에 저장

## 🛠️ 작업 상세 내용

- `WelfareCandidate`에 `application_forms: list[dict] = []` 필드 추가
- `rag_detail_node`에서 RAG 응답의 `application_forms` 매핑 추가
- `_DUMMY_DETAIL`에 `application_forms` 샘플 데이터 추가 및 매핑 검증 테스트 추가

## 🧪 테스트 여부 및 확인 내용

- 기존 23개 테스트 전부 통과
- `application_forms` 있을 때 정상 매핑 확인
- `application_forms` 없을 때 `[]` 기본값 확인

## 💬 기타 / 참고사항

- `application_url`: 복지로 서비스 상세 페이지 링크
- `application_forms`: 실제 서류 파일 다운로드 링크 (`[{"title", "url", "file_type"}]`)
- 추후 k-skill 연동 시 `selected_service.application_forms`에서 읽어 사용

## 🔗 연관 이슈

- Closes #63