### PR TITLE
feat: field_extractor에 1차 인터뷰 유저 프로필 전달

### DIFF
--- a/agents/rag_detail.py
+++ b/agents/rag_detail.py
@@ -102,6 +102,12 @@ async def rag_detail_node(state: AgentState) -> dict:
         }
     )
 
+    user_info = {
+        k: v
+        for k, v in profile.model_dump(exclude={"extra_fields"}).items()
+        if v is not None
+    }
+
     schemas: list[dict] = []
     try:
         schemas = await hwnv_client.extract_extra_field_schemas(
@@ -110,7 +116,8 @@ async def rag_detail_node(state: AgentState) -> dict:
                 "tgtr_dtl_cn": detail.get("tgtr_dtl_cn", ""),
                 "slct_crit_cn": detail.get("slct_crit_cn", ""),
                 "trgter_indvdl": detail.get("trgter_indvdl", []),
-            }
+            },
+            user_info=user_info,
         )
     except Exception as e:
         print(f"[hwnv field_extractor 오류] {type(e).__name__}: {e}")

--- a/tools/hwnv_client.py
+++ b/tools/hwnv_client.py
@@ -182,17 +182,22 @@ async def extract_detail_value(
         return _parse_json_content(content)
 
 
-async def extract_extra_field_schemas(service_info: dict) -> list[dict]:
+async def extract_extra_field_schemas(
+    service_info: dict, user_info: dict | None = None
+) -> list[dict]:
     """field_extractor 프로필로 서비스 추가 필드 스키마를 생성합니다.
 
     Args:
         service_info: {serv_nm, tgtr_dtl_cn, slct_crit_cn, trgter_indvdl}
+        user_info: 1차 인터뷰에서 수집한 UserProfile 값 (이미 알고 있는 필드 제외용)
 
     Returns:
         [{"key", "label", "type", "enum_values"?, "question_hint", "reason"}]
         실패 시 빈 리스트
     """
-    payload = {"service": service_info}
+    payload: dict = {"service": service_info}
+    if user_info:
+        payload["user"] = user_info
 
     async with httpx.AsyncClient(base_url=_BASE_URL, timeout=_TIMEOUT) as client:
         resp = await client.post(


### PR DESCRIPTION
## 📝 PR 설명

- `field_extractor` 모델 호출 시 1차 인터뷰에서 수집한 유저 프로필을 함께 전달하도록 수정

## 🛠️ 작업 상세 내용

- `hwnv_client.py` — `extract_extra_field_schemas`에 `user_info: dict | None = None` 파라미터 추가, payload에 `"user"` 키로 포함
- `rag_detail.py` — `profile.model_dump(exclude={"extra_fields"})`로 1차 인터뷰 수집 값만 변환(None 제외)해서 전달

## 🧪 테스트 여부 및 확인 내용

- `pytest tests/test_rag_detail.py` 23개 전부 통과

## 💬 기타 / 참고사항

- llm 서버 `field_extractor` 프롬프트의 `[입력]` 스펙에 `user` 필드 추가가 함께 이루어져야 완전히 동작함

## 🔗 연관 이슈

- Closes #67