### PR TITLE
[AI] 로깅 및 에러 처리 강화

### DIFF
--- a/agents/detail_interview.py
+++ b/agents/detail_interview.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import TYPE_CHECKING
 
@@ -9,6 +10,8 @@ from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.types import Command, interrupt
 
 from tools import hwnv_client
+
+logger = logging.getLogger("bokjidream.detail_interview")
 
 if TYPE_CHECKING:
     from graph.state import AgentState, UserProfile
@@ -103,7 +106,7 @@ async def detail_interview_node(state: AgentState) -> dict | Command:
 
     field_info = _get_field_info(field, extra_schemas)
     if field_info is None:
-        print(f"[DEBUG] 알 수 없는 2단계 필드 스킵: {field}")
+        logger.debug("[detail_interview] 알 수 없는 필드 스킵: %s", field)
         return {"detail_missing_fields": [f for f in missing if f != field]}
 
     question = state.get("pending_question")
@@ -116,7 +119,12 @@ async def detail_interview_node(state: AgentState) -> dict | Command:
                 pre_user_message=state.get("detail_last_answer", ""),
             )
         except Exception as e:
-            print(f"[hwnv ask_detail_question 오류] {type(e).__name__}: {e}")
+            logger.warning(
+                "[detail_interview] ask_detail_question 실패 field=%s: %s",
+                field,
+                e,
+                exc_info=True,
+            )
             error_msg = (
                 "죄송합니다. 질문 생성 중 오류가 발생했습니다. "
                 "잠시 후 다시 시도해 주세요."
@@ -134,7 +142,12 @@ async def detail_interview_node(state: AgentState) -> dict | Command:
             field_info, question, user_answer
         )
     except Exception as e:
-        print(f"[hwnv extract_detail_value 오류] {type(e).__name__}: {e}")
+        logger.warning(
+            "[detail_interview] extract_detail_value 실패 field=%s: %s",
+            field,
+            e,
+            exc_info=True,
+        )
         return {
             "detail_missing_fields": missing,
             "detail_current_field": field,
@@ -146,7 +159,9 @@ async def detail_interview_node(state: AgentState) -> dict | Command:
     ai_msg = AIMessage(content=question)
     human_msg = HumanMessage(content=user_answer)
 
-    print(f"[DEBUG] 2단계 필드: {field}, 추출 결과: {result}")
+    logger.debug(
+        "[detail_interview] 2단계 필드 추출: field=%s result=%s", field, result
+    )
 
     if result.get("exist") and result.get("value") is not None:
         new_profile = _apply_extracted_value(

--- a/agents/document_guidance.py
+++ b/agents/document_guidance.py
@@ -1,10 +1,14 @@
 """서류 안내 노드 — required_documents를 사용자 상황에 맞게 안내합니다."""
 
+import logging
+
 from langchain_core.messages import AIMessage
 
 from graph.state import AgentState, UserProfile, WelfareCandidate
 from tools.llm import get_llm
 from tools.prompt_loader import load_prompt
+
+logger = logging.getLogger("bokjidream.document_guidance")
 
 
 def _format_user_info(profile: UserProfile) -> str:
@@ -64,7 +68,7 @@ async def document_guidance_node(state: AgentState) -> dict:
         response = await llm.ainvoke(prompt)
         guidance = response.content
     except Exception as e:
-        print(f"[LLM 오류] document_guidance {type(e).__name__}: {e}")
+        logger.warning("[document_guidance] LLM 호출 실패: %s", e, exc_info=True)
         guidance = (
             f"'{selected.serv_nm}' 서류 안내 생성 중 오류가 발생했습니다. "
             "해당 기관에 직접 문의해 주세요."

--- a/agents/draft_writer.py
+++ b/agents/draft_writer.py
@@ -1,11 +1,14 @@
 """신청서 작성 가이드 노드 — application_method 원문 기반 신청 안내 생성."""
 
+import logging
 from pathlib import Path
 
 from langchain_core.messages import AIMessage
 
 from graph.state import AgentState, UserProfile, WelfareCandidate
 from tools.llm import get_llm
+
+logger = logging.getLogger("bokjidream.draft_writer")
 
 _PROMPT_PATH = Path(__file__).parent.parent / "prompts" / "draft_writer.txt"
 
@@ -80,7 +83,7 @@ async def draft_writer_node(state: AgentState) -> dict:
         response = await llm.ainvoke(prompt)
         guide = response.content
     except Exception as e:
-        print(f"[LLM 오류] draft_writer {type(e).__name__}: {e}")
+        logger.warning("[draft_writer] LLM 호출 실패: %s", e, exc_info=True)
         guide = (
             f"'{selected.serv_nm}' 신청 안내 생성 중 오류가 발생했습니다. "
             "해당 기관에 직접 문의해 주세요."

--- a/agents/form_filler.py
+++ b/agents/form_filler.py
@@ -151,6 +151,7 @@ async def form_filler_node(state: AgentState, config: RunnableConfig) -> dict:
             )
 
             if not field_mapping:
+                logger.warning("[form_filler] 필드 매핑 없음, 원본 유지: %s", title)
                 raw_path.rename(filled_path)
                 entry["status"] = "skipped"
                 entry["error"] = "LLM 필드 매핑 결과 없음"

--- a/agents/initial_interview.py
+++ b/agents/initial_interview.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from langchain_core.messages import AIMessage, HumanMessage
@@ -15,6 +16,8 @@ from graph.state import (  # noqa: TCH001
     UserProfile,
 )
 from tools import hwnv_client
+
+logger = logging.getLogger("bokjidream.initial_interview")
 
 if TYPE_CHECKING:
     from graph.state import AgentState
@@ -82,7 +85,12 @@ async def initial_interview_node(state: AgentState) -> dict | Command:
                 pre_user_message=state.get("interview_last_answer", ""),
             )
         except Exception as e:
-            print(f"[hwnv ask_question 오류] {type(e).__name__}: {e}")
+            logger.warning(
+                "[initial_interview] ask_question 실패 field=%s: %s",
+                field,
+                e,
+                exc_info=True,
+            )
             error_msg = (
                 "죄송합니다. 질문 생성 중 오류가 발생했습니다. "
                 "잠시 후 다시 시도해 주세요."
@@ -98,7 +106,12 @@ async def initial_interview_node(state: AgentState) -> dict | Command:
     try:
         result = await hwnv_client.extract_value(field, question, user_answer)
     except Exception as e:
-        print(f"[hwnv extract_value 오류] {type(e).__name__}: {e}")
+        logger.warning(
+            "[initial_interview] extract_value 실패 field=%s: %s",
+            field,
+            e,
+            exc_info=True,
+        )
         return {
             "initial_missing_fields": missing,
             "interview_current_field": field,

--- a/agents/rag_detail.py
+++ b/agents/rag_detail.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from langchain_core.messages import AIMessage
 
 import tools.hwnv_client as hwnv_client
 import tools.rag_client as rag_client
+
+logger = logging.getLogger("bokjidream.rag_detail")
 
 if TYPE_CHECKING:
     from graph.state import AgentState, UserProfile, WelfareCandidate
@@ -120,7 +123,7 @@ async def rag_detail_node(state: AgentState) -> dict:
             user_info=user_info,
         )
     except Exception as e:
-        print(f"[hwnv field_extractor 오류] {type(e).__name__}: {e}")
+        logger.warning("[rag_detail] field_extractor 실패: %s", e, exc_info=True)
 
     regular_missing, extra_schemas = _classify_schemas(schemas, profile)
     missing_fields = regular_missing + [f"extra:{s['key']}" for s in extra_schemas]

--- a/agents/rag_search.py
+++ b/agents/rag_search.py
@@ -1,6 +1,7 @@
 """RAG 검색 노드 — UserProfile로 복지 서비스 후보 목록 조회."""
 
 import asyncio
+import logging
 import os
 
 from langchain_core.messages import AIMessage
@@ -8,6 +9,8 @@ from langchain_core.messages import AIMessage
 import tools.hwnv_client as hwnv_client
 import tools.rag_client as rag_client
 from graph.state import AgentState, UserProfile, WelfareCandidate
+
+logger = logging.getLogger("bokjidream.rag_search")
 
 
 def _profile_to_dict(profile: UserProfile) -> dict:
@@ -53,7 +56,9 @@ async def rag_search_node(state: AgentState) -> dict:
             continue
 
     if results is None and last_error is not None:
-        print(f"[RAG 오류] {type(last_error).__name__}: {last_error}")
+        logger.warning(
+            "[rag_search] RAG 검색 실패: %s", last_error, exc_info=last_error
+        )
 
     if results is None:
         error_msg = (

--- a/agents/report_writer.py
+++ b/agents/report_writer.py
@@ -1,11 +1,14 @@
 """최종 보고서 에이전트 — draft_writer 가이드를 사용자 친화적 마크다운으로 재구성."""
 
+import logging
 from pathlib import Path
 
 from langchain_core.messages import AIMessage
 
 from graph.state import AgentState, WelfareCandidate
 from tools.llm import get_llm
+
+logger = logging.getLogger("bokjidream.report_writer")
 
 _PROMPT_PATH = Path(__file__).parent.parent / "prompts" / "report_writer.txt"
 
@@ -41,7 +44,7 @@ async def report_writer_node(state: AgentState) -> dict:
         response = await llm.ainvoke(prompt)
         report = response.content
     except Exception as e:
-        print(f"[LLM 오류] report_writer {type(e).__name__}: {e}")
+        logger.warning("[report_writer] LLM 호출 실패: %s", e, exc_info=True)
         report = (
             f"'{selected.serv_nm}' 보고서 생성 중 오류가 발생했습니다. "
             "잠시 후 다시 시도해 주세요."

--- a/server.py
+++ b/server.py
@@ -68,6 +68,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="BokjiDream AI Server", lifespan=lifespan)
 
 _CORS_ORIGINS = os.getenv("CORS_ALLOW_ORIGINS", "http://localhost:3000").split(",")
+_SERVER_ERROR_MSG = "서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
 
 app.add_middleware(
     CORSMiddleware,
@@ -298,7 +299,7 @@ async def chat_start() -> ChatResponse:
         return response
     except Exception as e:
         logger.exception("[thread=%s] /chat/start 오류", thread_id)
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail=_SERVER_ERROR_MSG) from e
 
 
 @app.post("/chat/message", response_model=ChatResponse)
@@ -325,4 +326,4 @@ async def chat_message(body: MessageRequest) -> ChatResponse:
         return response
     except Exception as e:
         logger.exception("[thread=%s] /chat/message 오류", thread_id)
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail=_SERVER_ERROR_MSG) from e

--- a/tools/hwnv_client.py
+++ b/tools/hwnv_client.py
@@ -1,10 +1,13 @@
 """hwnv.cloud 인터뷰 API 클라이언트."""
 
 import json
+import logging
 import os
 
 import httpx
 from dotenv import load_dotenv
+
+logger = logging.getLogger("bokjidream.hwnv_client")
 
 load_dotenv()
 
@@ -254,4 +257,7 @@ async def generate_eligibility_reason(
             resp.raise_for_status()
             return resp.json()["choices"][0]["message"]["content"]
     except Exception:
+        logger.warning(
+            "eligibility_reason 생성 실패: serv_nm=%s", serv_nm, exc_info=True
+        )
         return ""


### PR DESCRIPTION
## 📝 PR 설명

- `print()` 디버그 출력을 `logging` 모듈로 통일하고, silent failure에 경고 로그를 추가
- 500 오류 응답에서 내부 예외 메시지가 클라이언트에 노출되는 문제 수정

## 🛠️ 작업 상세 내용

- `tools/hwnv_client.py` — `generate_eligibility_reason()` 예외 시 `logger.warning` 추가 (기존 `return ""` silent failure)
- `agents/form_filler.py` — `field_mapping` 비어서 skipped 처리될 때 `logger.warning` 추가
- `server.py` — `HTTPException(500, detail=str(e))` → 클라이언트엔 일반 메시지, 서버 로그엔 기존 `logger.exception` 유지
- `agents/` 7개 파일 (`rag_search`, `rag_detail`, `initial_interview`, `detail_interview`, `document_guidance`, `draft_writer`, `report_writer`) — `print(f"[DEBUG/오류]...")` 11곳 → `logging.getLogger(__name__)` 통일

## 🧪 테스트 여부 및 확인 내용

- `uv run ruff check .` 통과
- `uv run pytest tests/ -v` — 145개 통과 (기존 postgres Windows 환경 이슈 2개 제외)

## 📸 스크린샷 (선택)

## 💬 기타 / 참고사항

- 모든 로거는 `bokjidream.<모듈명>` 네임스페이스 사용 (server.py `logging.config`에서 이미 설정된 핸들러 활용)

## 🔗 연관 이슈

- Closes #71