### PR TITLE
[AI] RAG 재시도 개선 및 타임아웃 환경변수화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ CORS_ALLOW_ORIGINS=http://localhost:3000
 # 통합 테스트(test_rag_integration.py)는 실제 RAG 서버가 실행 중이어야 함
 RAG_SERVICE_URL=http://localhost:8001
 RAG_SEARCH_TOP_K=5
+RAG_TIMEOUT=10.0
 
 # hwnv.cloud 인터뷰 API — 외부 API로 사용 시 https://hwnv.cloud 로 변경
 HWNV_SERVICE_URL=http://localhost:8002

--- a/agents/rag_search.py
+++ b/agents/rag_search.py
@@ -1,13 +1,23 @@
 """RAG 검색 노드 — UserProfile로 복지 서비스 후보 목록 조회."""
 
 import asyncio
+import logging
 import os
 
 from langchain_core.messages import AIMessage
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 import tools.hwnv_client as hwnv_client
 import tools.rag_client as rag_client
 from graph.state import AgentState, UserProfile, WelfareCandidate
+
+logger = logging.getLogger("bokjidream.rag_search")
+
+
+@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=4))
+async def _search_with_retry(profile: dict, top_k: int) -> list[dict]:
+    """RAG 검색 — 최대 3회 지수 백오프 재시도 (1s→2s→4s)."""
+    return await rag_client.search(profile=profile, top_k=top_k)
 
 
 def _profile_to_dict(profile: UserProfile) -> dict:
@@ -39,21 +49,11 @@ async def rag_search_node(state: AgentState) -> dict:
     profile: UserProfile = state["user_profile"]
     top_k = int(os.getenv("RAG_SEARCH_TOP_K", "5"))
 
-    # RAG 호출 (1회 재시도)
     results = None
-    last_error = None
-    for _ in range(2):
-        try:
-            results = await rag_client.search(
-                profile=_profile_to_dict(profile), top_k=top_k
-            )
-            break
-        except Exception as e:
-            last_error = e
-            continue
-
-    if results is None and last_error is not None:
-        print(f"[RAG 오류] {type(last_error).__name__}: {last_error}")
+    try:
+        results = await _search_with_retry(_profile_to_dict(profile), top_k)
+    except Exception as e:
+        logger.warning("[rag_search] RAG 검색 최종 실패: %s", e, exc_info=True)
 
     if results is None:
         error_msg = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "langgraph-checkpoint-sqlite>=3.0.3",
     "langgraph-checkpoint-postgres>=3.1.0",
     "psycopg[binary]>=3.3.4",
+    "tenacity>=8.0.0",
 ]
 
 [tool.ruff]

--- a/tests/test_rag_search.py
+++ b/tests/test_rag_search.py
@@ -168,22 +168,15 @@ class TestRagSearchNode:
         assert isinstance(result["messages"][0], AIMessage)
         assert "찾지 못했습니다" in result["messages"][0].content
 
-    @patch(
-        "agents.rag_search.hwnv_client.generate_eligibility_reason",
-        new_callable=AsyncMock,
-    )
-    @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
-    async def test_network_error_retries_and_returns_error_message(
-        self, mock_search, mock_reason
-    ):
-        mock_search.side_effect = Exception("Connection error")
+    @patch("agents.rag_search._search_with_retry", new_callable=AsyncMock)
+    async def test_network_error_returns_error_message(self, mock_retry):
+        mock_retry.side_effect = Exception("Connection error")
 
         result = await rag_search_node(_make_state())
 
         assert result["welfare_candidates"] == []
         assert isinstance(result["messages"][0], AIMessage)
         assert "연결 오류" in result["messages"][0].content
-        assert mock_search.call_count == 2  # 1회 재시도 확인
 
     @patch(
         "agents.rag_search.hwnv_client.generate_eligibility_reason",

--- a/tools/rag_client.py
+++ b/tools/rag_client.py
@@ -4,7 +4,7 @@ import os
 
 import httpx
 
-_TIMEOUT = 10.0
+_TIMEOUT = float(os.getenv("RAG_TIMEOUT", "10.0"))
 
 
 def _base_url() -> str:


### PR DESCRIPTION
## 📝 PR 설명

- RAG 서버 순간 장애 시 단순 2회 루프를 tenacity 지수 백오프 재시도로 교체
- 하드코딩된 타임아웃을 환경변수로 분리

## 🛠️ 작업 상세 내용

- `tools/rag_client.py` — `_TIMEOUT = 10.0` 하드코딩 → `RAG_TIMEOUT` 환경변수로 분리 (기본값 10.0)
- `agents/rag_search.py` — `for _ in range(2)` 단순 루프 → `tenacity` 지수 백오프 (`wait_exponential(min=1, max=4)`, `stop_after_attempt(3)`)로 교체
- `pyproject.toml` — `tenacity>=8.0.0` 명시적 의존성 추가 (기존 트랜지티브 의존성으로 설치는 됐으나 미명시)
- `.env.example` — `RAG_TIMEOUT=10.0` 항목 추가
- `tests/test_rag_search.py` — retry 횟수 어설션을 `_search_with_retry` 직접 패치 방식으로 교체

## 🧪 테스트 여부 및 확인 내용

- `uv run ruff check .` 통과
- `uv run pytest tests/test_rag_search.py -v` — 14개 전체 통과
- `uv run pytest tests/ -v` — 145개 통과

## 📸 스크린샷 (선택)

## 💬 기타 / 참고사항

- `tools/hwnv_client.py`의 `HWNV_TIMEOUT`은 이미 env 읽고 있어 변경 없음

## 🔗 연관 이슈

- Closes #72