### PR TITLE
fix: application_forms 없으면 draft 플로우 건너뛰기

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,6 @@ RAG_TIMEOUT=10.0
 # hwnv.cloud 인터뷰 API — 외부 API로 사용 시 https://hwnv.cloud 로 변경
 HWNV_SERVICE_URL=http://localhost:8002
 HWNV_TIMEOUT=300.0
+
+# draft_writer — PDF/기타 신청서의 LLM 가이드 필드 최대 개수 (기본값 5)
+DRAFT_FIELD_LIMIT=5

--- a/agents/draft_writer.py
+++ b/agents/draft_writer.py
@@ -20,7 +20,6 @@ import pdfplumber
 from langchain_core.runnables import RunnableConfig
 from langgraph.types import interrupt
 
-from graph.config import is_skip_interview
 from graph.state import AgentState, UserProfile, WelfareCandidate
 from tools.hwp_filler import (
     download_hwp,
@@ -88,7 +87,7 @@ def _section_rank(label: str) -> int:
 
 
 _HWP_DOWNLOAD_RETRIES = int(os.getenv("HWP_DOWNLOAD_RETRIES", "4"))
-_DRAFT_FIELD_LIMIT = int(os.getenv("DRAFT_FIELD_LIMIT", "8"))
+_DRAFT_FIELD_LIMIT = int(os.getenv("DRAFT_FIELD_LIMIT", "5"))
 
 
 def _is_application_form(title: str) -> bool:
@@ -493,8 +492,6 @@ async def draft_field_extractor_node(state: AgentState, config: RunnableConfig) 
     profile: UserProfile = state["user_profile"]
 
     forms = selected.application_forms or []
-    if not forms and is_skip_interview():
-        forms = _get_test_fixture_forms()
 
     hwp_forms = [f for f in forms if f.get("file_type", "").lower() in _SUPPORTED_HWP]
     hwp_form = next(
@@ -641,8 +638,6 @@ async def draft_writer_node(state: AgentState, config: RunnableConfig) -> dict:
     user_draft_fields: dict[str, str] = state.get("user_draft_fields", {})
 
     forms = selected.application_forms or []
-    if not forms and is_skip_interview():
-        forms = _get_test_fixture_forms()
 
     if not forms:
         logger.info("[draft_writer] application_forms 없음 — skip")

--- a/agents/draft_writer.py
+++ b/agents/draft_writer.py
@@ -496,7 +496,7 @@ async def draft_field_extractor_node(state: AgentState, config: RunnableConfig) 
     hwp_forms = [f for f in forms if f.get("file_type", "").lower() in _SUPPORTED_HWP]
     hwp_form = next(
         (f for f in hwp_forms if _is_application_form(f.get("title", ""))), None
-    ) or (hwp_forms[0] if hwp_forms else None)
+    )
 
     if not hwp_form:
         return {
@@ -654,7 +654,7 @@ async def draft_writer_node(state: AgentState, config: RunnableConfig) -> dict:
     hwp_forms = [f for f in forms if f.get("file_type", "").lower() in _SUPPORTED_HWP]
     scanned_form = next(
         (f for f in hwp_forms if _is_application_form(f.get("title", ""))), None
-    ) or (hwp_forms[0] if hwp_forms else None)
+    )
 
     # 파일 타입별 코루틴 수집 — 원본 순서(index)를 키로 유지
     tasks: dict[int, object] = {}


### PR DESCRIPTION
## 📝 PR 설명

- `application_forms`가 비어있으면 SKIP_INTERVIEW 여부와 무관하게 draft 플로우 전체 건너뛰기

## 🛠️ 작업 상세 내용

- `draft_field_extractor_node`: 테스트 픽스처 주입 코드 제거
- `draft_writer_node`: 테스트 픽스처 주입 코드 제거
- `_get_test_fixture_forms()`는 단위 테스트용으로 유지

## 🧪 테스트 여부 및 확인 내용

- HWP 파일 없는 서비스(농촌출신대학생학자금융자 등) → draft_fields 인터럽트 없이 `type=done` 바로 반환 확인

## 🔗 연관 이슈

- Closes #83