### PR TITLE
fix: eligibility_reason 생성 복구

### DIFF
--- a/agents/rag_search.py
+++ b/agents/rag_search.py
@@ -1,11 +1,13 @@
 """RAG 검색 노드 — UserProfile로 복지 서비스 후보 목록 조회."""
 
+import asyncio
 import logging
 import os
 
 from langchain_core.messages import AIMessage
 from tenacity import retry, stop_after_attempt, wait_exponential
 
+import tools.hwnv_client as hwnv_client
 import tools.rag_client as rag_client
 from graph.state import AgentState, UserProfile, WelfareCandidate
 
@@ -73,6 +75,18 @@ async def rag_search_node(state: AgentState) -> dict:
     # score 내림차순 정렬
     results.sort(key=lambda x: x.get("score", 0.0), reverse=True)
 
+    # 후보별 선정 이유를 병렬로 생성
+    reasons = await asyncio.gather(
+        *[
+            hwnv_client.generate_eligibility_reason(
+                serv_nm=item["serv_nm"],
+                serv_dgst=item["serv_dgst"],
+                user=_profile_to_dict(profile),
+            )
+            for item in results
+        ]
+    )
+
     candidates = [
         WelfareCandidate(
             serv_id=item["serv_id"],
@@ -81,9 +95,11 @@ async def rag_search_node(state: AgentState) -> dict:
             department=item.get("department", ""),
             score=item.get("score", 0.0),
             priority=priority,
-            eligibility_reason="",
+            eligibility_reason=reason,
         )
-        for priority, item in enumerate(results, start=1)
+        for priority, (item, reason) in enumerate(
+            zip(results, reasons, strict=False), start=1
+        )
     ]
 
     return {"welfare_candidates": candidates}

--- a/tests/test_rag_search.py
+++ b/tests/test_rag_search.py
@@ -115,9 +115,14 @@ class TestProfileToDict:
 
 
 class TestRagSearchNode:
+    @patch(
+        "agents.rag_search.hwnv_client.generate_eligibility_reason",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
-    async def test_returns_candidates_on_success(self, mock_search):
+    async def test_returns_candidates_on_success(self, mock_search, mock_reason):
         mock_search.return_value = _DUMMY_RAG_RESULTS
+        mock_reason.return_value = ""
 
         result = await rag_search_node(_make_state())
 
@@ -126,13 +131,18 @@ class TestRagSearchNode:
             isinstance(c, WelfareCandidate) for c in result["welfare_candidates"]
         )
 
+    @patch(
+        "agents.rag_search.hwnv_client.generate_eligibility_reason",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
-    async def test_priority_assigned_by_score_order(self, mock_search):
+    async def test_priority_assigned_by_score_order(self, mock_search, mock_reason):
         unsorted = [
             {**_DUMMY_RAG_RESULTS[1], "score": 0.80},
             {**_DUMMY_RAG_RESULTS[0], "score": 0.95},
         ]
         mock_search.return_value = unsorted
+        mock_reason.return_value = ""
 
         result = await rag_search_node(_make_state())
 
@@ -162,11 +172,16 @@ class TestRagSearchNode:
         assert isinstance(result["messages"][0], AIMessage)
         assert "연결 오류" in result["messages"][0].content
 
+    @patch(
+        "agents.rag_search.hwnv_client.generate_eligibility_reason",
+        new_callable=AsyncMock,
+    )
     @patch("agents.rag_search.rag_client.search", new_callable=AsyncMock)
-    async def test_eligibility_reason_is_empty(self, mock_search):
+    async def test_eligibility_reason_is_populated(self, mock_search, mock_reason):
         mock_search.return_value = _DUMMY_RAG_RESULTS
+        mock_reason.return_value = "해당 서비스 선정 이유"
 
         result = await rag_search_node(_make_state())
 
         for candidate in result["welfare_candidates"]:
-            assert candidate.eligibility_reason == ""
+            assert candidate.eligibility_reason == "해당 서비스 선정 이유"

--- a/tools/hwnv_client.py
+++ b/tools/hwnv_client.py
@@ -220,3 +220,41 @@ async def extract_extra_field_schemas(
         content = resp.json()["choices"][0]["message"]["content"]
         result = _parse_json_content(content)
         return result.get("extra_fields", [])
+
+
+async def generate_eligibility_reason(
+    serv_nm: str,
+    serv_dgst: str,
+    user: dict,
+) -> str:
+    """elig_reasoner 프로필로 서비스 선정 이유를 한 문장 생성합니다.
+
+    Returns:
+        선정 이유 문자열. 실패 시 빈 문자열.
+    """
+    payload = {
+        "user": user,
+        "service": {
+            "serv_nm": serv_nm,
+            "serv_dgst": serv_dgst,
+            "trgterIndvdlArray": "",
+        },
+    }
+    try:
+        async with httpx.AsyncClient(base_url=_BASE_URL, timeout=_TIMEOUT) as client:
+            resp = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "elig_reasoner",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": json.dumps(payload, ensure_ascii=False),
+                        }
+                    ],
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()["choices"][0]["message"]["content"]
+    except Exception:
+        return ""


### PR DESCRIPTION
## 📝 PR 설명

- `3834446` 커밋에서 의도치 않게 제거된 서비스 선정 이유 생성 기능을 원복합니다.

## 🛠️ 작업 상세 내용

- `tools/hwnv_client.py`: `generate_eligibility_reason()` 함수 복구 (elig_reasoner 모델 호출, 실패 시 빈 문자열 폴백)
- `agents/rag_search.py`: `asyncio.gather()`로 후보별 병렬 생성 복구
- `tests/test_rag_search.py`: `hwnv_client` 모킹 추가 및 `eligibility_reason` 채워짐 단언으로 수정

## 🧪 테스트 여부 및 확인 내용

- 전체 테스트 14/14 통과
- ruff lint/format 통과

## 🔗 연관 이슈

- Closes #89