### PR TITLE
chore: add Dockerfile and .dockerignore for Railway deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+checkpoints.db*
+filled_forms/
+tests/
+docs/
+.git/
+.DS_Store
+*.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+# Node.js 20 설치
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+        build-essential \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv 설치
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# Python 의존성 설치
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+# Node.js 의존성 설치
+COPY scripts/package.json scripts/package-lock.json ./scripts/
+RUN npm install --prefix ./scripts --omit=dev
+
+# 소스 복사
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uv", "run", "uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary

- Railway 배포 시 nixpacks 대신 Dockerfile을 사용하도록 추가
- Node.js 20 + Python 3.11 환경으로 `fill_hwp.js` 실행 가능
- `.dockerignore`로 불필요한 파일 제외

## 배경

Railway가 Dockerfile 없이 nixpacks로 빌드하면 Node.js가 설치되지 않아
`[Errno 2] No such file or directory: 'node'` 에러 발생 → HWP 자동 채우기 전면 실패

## Test plan

- [ ] Railway에서 Dockerfile 빌드 성공 확인
- [ ] HWP 라벨 스캔 및 자동 채우기 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)