### PR TITLE
fix: add nixpacks.toml for Railway deployment

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,11 @@
+[phases.setup]
+nixPkgs = ["nodejs_20"]
+
+[phases.install]
+cmds = [
+  "uv sync --frozen --no-dev",
+  "npm install --prefix ./scripts --omit=dev"
+]
+
+[start]
+cmd = "uv run uvicorn server:app --host 0.0.0.0 --port ${PORT:-8000}"


### PR DESCRIPTION
## Summary

- `\$PORT` 환경변수 미확장 문제 수정 → `${PORT:-8000}` 사용
- Node.js 20 설치로 `fill_hwp.js` 실행 환경 확보
- `scripts/` npm 의존성 설치 단계 추가

## 배경

Railway nixpacks 빌드 시 `uvicorn --port \$PORT`에서 `\$PORT`가 문자열로 그대로 전달되어 크래시 루프 발생.
또한 Node.js가 없어 HWP 자동 채우기도 전면 실패 중.

## Test plan

- [ ] Railway 배포 후 크래시 루프 해소 확인
- [ ] HWP 라벨 스캔 및 자동 채우기 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)