### PR TITLE
fix: add cacert to nixpacks for HTTPS connections

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-nixPkgs = ["nodejs_20"]
+nixPkgs = ["nodejs_20", "cacert"]
 
 [phases.install]
 cmds = [


### PR DESCRIPTION
## Summary

- `cacert` 패키지 추가로 Railway nixpacks 환경의 SSL CA 인증서 누락 문제 수정
- bokjiro.go.kr HWP 다운로드 시 TLS 연결 실패 해결 시도

🤖 Generated with [Claude Code](https://claude.com/claude-code)