### PR TITLE
Railway Deployment #0151b5 fix: add python311 and uv to nixpacks

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-nixPkgs = ["nodejs_20", "cacert"]
+nixPkgs = ["nodejs_20", "python311", "uv"]
 
 [phases.install]
 cmds = [


### PR DESCRIPTION
## Problem

The build fails with `uv: command not found` (exit code 127) because nixpacks.toml only listed `nodejs_20` (and `cacert`) in `[phases.setup]`. When the setup phase is explicitly defined, Nixpacks does not auto-detect or install Python/uv, so the `uv sync` install command has no binary to run. The `cacert` package also causes a Nix collision with the base image's built-in CA certificates.

## Solution

Replaced `cacert` with `python311` and `uv` in the `nixPkgs` list. This provides the Python 3.11 runtime (matching `requires-python = ">=3.11"` in pyproject.toml) and the uv binary needed by both the install and start commands, while removing the conflicting cacert package.

### Changes
- **Modified** `nixpacks.toml`

### Context
- **Deployment**: [#0151b5](https://railway.com/project/6fc3b14e-aac8-42f8-8c9e-0b9804d8dfb4/environment/2d6d4660-5d44-4489-bd33-61b07e64d84a/deployment/0151b54c-b771-48f0-9c78-18f5784295bb)
- **Failed commit**: `cd795e4`

---
*Generated by [Railway](https://railway.com)*