### PR TITLE
fix(nixpacks): replace cacert with python311 and uv

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-nixPkgs = ["nodejs_20", "cacert"]
+nixPkgs = ["nodejs_20", "python311", "uv"]
 
 [phases.install]
 cmds = [


### PR DESCRIPTION
## 📝 PR 설명

- Nixpacks 빌드 실패 2가지 원인을 한 번에 수정

## 🛠️ 작업 상세 내용

- `cacert` 제거: Nixpacks 환경에 `nss-cacert-3.104`가 이미 포함되어 있어 `cacert`(3.107) 추가 시 `/etc/ssl/certs/ca-no-trust-rules-bundle.crt` 파일 충돌 발생 (PR #96에서 도입된 문제)
- `python311`, `uv` 추가: PR #95에서 Dockerfile 제거 후 setup 단계에 Python/uv가 없어 install 단계의 `uv sync --frozen --no-dev` 실패

## 🧪 테스트 여부 및 확인 내용

- 빌드 로그 분석 기반 수정, CI 빌드로 검증 필요

## 📸 스크린샷 (선택)

## 💬 기타 / 참고사항

- 변경: `[nodejs_20, cacert]` → `[nodejs_20, python311, uv]`

## 🔗 연관 이슈

- 해당 PR이 머지되면 이슈가 자동으로 닫힙니다.